### PR TITLE
Add Objective-C support and example; reorganize project [WIP]

### DIFF
--- a/Directions Example.xcodeproj/project.pbxproj
+++ b/Directions Example.xcodeproj/project.pbxproj
@@ -8,13 +8,37 @@
 
 /* Begin PBXBuildFile section */
 		6A0C780296F2AD5A7682A87D /* Pods_Unit_Tests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 371BFE7855E3EA8B44CA2B5F /* Pods_Unit_Tests.framework */; };
+		96EB889E1C87B0C200329BFE /* AppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 96EB889B1C87B0C200329BFE /* AppDelegate.m */; };
+		96EB889F1C87B0C200329BFE /* ViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 96EB889D1C87B0C200329BFE /* ViewController.m */; };
+		96F7482E1C878D9000E22DE1 /* MapboxDirections.h in Headers */ = {isa = PBXBuildFile; fileRef = 96F7482D1C878D9000E22DE1 /* MapboxDirections.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		96F748441C878EE200E22DE1 /* MapboxDirections.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96F748431C878EE200E22DE1 /* MapboxDirections.swift */; };
+		96F748531C87906D00E22DE1 /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 96F748521C87906D00E22DE1 /* main.m */; };
+		96F7486B1C87924C00E22DE1 /* MapboxDirections.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 96F7482B1C878D9000E22DE1 /* MapboxDirections.framework */; };
+		96F7486C1C87924C00E22DE1 /* MapboxDirections.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 96F7482B1C878D9000E22DE1 /* MapboxDirections.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		96F748701C87925C00E22DE1 /* MapboxDirections.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 96F7482B1C878D9000E22DE1 /* MapboxDirections.framework */; };
+		96F748711C87925C00E22DE1 /* MapboxDirections.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 96F7482B1C878D9000E22DE1 /* MapboxDirections.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		96F748781C87956300E22DE1 /* Launch Screen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 96F748771C87956300E22DE1 /* Launch Screen.storyboard */; };
+		96F748791C87956300E22DE1 /* Launch Screen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 96F748771C87956300E22DE1 /* Launch Screen.storyboard */; };
 		DD6254541AE70C1700017857 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD6254531AE70C1700017857 /* AppDelegate.swift */; };
 		DD6254561AE70C1700017857 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD6254551AE70C1700017857 /* ViewController.swift */; };
-		DD6254741AE70CB700017857 /* MapboxDirections.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD6254731AE70CB700017857 /* MapboxDirections.swift */; };
 		DDF1E8671BD8580800C40C78 /* UnitTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDF1E8661BD8580800C40C78 /* UnitTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
+		96F7486D1C87924C00E22DE1 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = DD6254461AE70C1700017857 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 96F7482A1C878D9000E22DE1;
+			remoteInfo = MapboxDirections;
+		};
+		96F748721C87925C00E22DE1 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = DD6254461AE70C1700017857 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 96F7482A1C878D9000E22DE1;
+			remoteInfo = MapboxDirections;
+		};
 		DDF1E8691BD8580800C40C78 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = DD6254461AE70C1700017857 /* Project object */;
@@ -24,14 +48,49 @@
 		};
 /* End PBXContainerItemProxy section */
 
+/* Begin PBXCopyFilesBuildPhase section */
+		96F7486F1C87924C00E22DE1 /* Embed Frameworks */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 10;
+			files = (
+				96F7486C1C87924C00E22DE1 /* MapboxDirections.framework in Embed Frameworks */,
+			);
+			name = "Embed Frameworks";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		96F748741C87925C00E22DE1 /* Embed Frameworks */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 10;
+			files = (
+				96F748711C87925C00E22DE1 /* MapboxDirections.framework in Embed Frameworks */,
+			);
+			name = "Embed Frameworks";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXCopyFilesBuildPhase section */
+
 /* Begin PBXFileReference section */
 		371BFE7855E3EA8B44CA2B5F /* Pods_Unit_Tests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Unit_Tests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		96EB889A1C87B0C200329BFE /* AppDelegate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = AppDelegate.h; path = "Directions Example/AppDelegate.h"; sourceTree = SOURCE_ROOT; };
+		96EB889B1C87B0C200329BFE /* AppDelegate.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = AppDelegate.m; path = "Directions Example/AppDelegate.m"; sourceTree = SOURCE_ROOT; };
+		96EB889C1C87B0C200329BFE /* ViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ViewController.h; path = "Directions Example/ViewController.h"; sourceTree = SOURCE_ROOT; };
+		96EB889D1C87B0C200329BFE /* ViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = ViewController.m; path = "Directions Example/ViewController.m"; sourceTree = SOURCE_ROOT; };
+		96F7482B1C878D9000E22DE1 /* MapboxDirections.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = MapboxDirections.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		96F7482D1C878D9000E22DE1 /* MapboxDirections.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MapboxDirections.h; sourceTree = "<group>"; };
+		96F7482F1C878D9000E22DE1 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		96F748431C878EE200E22DE1 /* MapboxDirections.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = MapboxDirections.swift; path = ../MBDirections/MapboxDirections.swift; sourceTree = "<group>"; };
+		96F7484F1C87906D00E22DE1 /* Example (Objective-C).app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "Example (Objective-C).app"; sourceTree = BUILT_PRODUCTS_DIR; };
+		96F748521C87906D00E22DE1 /* main.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = main.m; path = "Supporting Files/main.m"; sourceTree = "<group>"; };
+		96F748771C87956300E22DE1 /* Launch Screen.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; name = "Launch Screen.storyboard"; path = "Supporting Files/Launch Screen.storyboard"; sourceTree = "<group>"; };
 		D4657820F4366F9DB1C432FB /* Pods-Unit Tests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Unit Tests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-Unit Tests/Pods-Unit Tests.debug.xcconfig"; sourceTree = "<group>"; };
-		DD62544E1AE70C1700017857 /* Directions Example.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "Directions Example.app"; sourceTree = BUILT_PRODUCTS_DIR; };
-		DD6254521AE70C1700017857 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		DD62544E1AE70C1700017857 /* Example (Swift).app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "Example (Swift).app"; sourceTree = BUILT_PRODUCTS_DIR; };
+		DD6254521AE70C1700017857 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; name = Info.plist; path = "Supporting Files/Info.plist"; sourceTree = "<group>"; };
 		DD6254531AE70C1700017857 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		DD6254551AE70C1700017857 /* ViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewController.swift; sourceTree = "<group>"; };
-		DD6254731AE70CB700017857 /* MapboxDirections.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = MapboxDirections.swift; path = ../MapboxDirections.swift; sourceTree = "<group>"; };
 		DDF1E8641BD8580800C40C78 /* Unit Tests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "Unit Tests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		DDF1E8661BD8580800C40C78 /* UnitTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnitTests.swift; sourceTree = "<group>"; };
 		DDF1E8681BD8580800C40C78 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -39,10 +98,26 @@
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
+		96F748271C878D9000E22DE1 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		96F7484C1C87906D00E22DE1 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				96F748701C87925C00E22DE1 /* MapboxDirections.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		DD62544B1AE70C1700017857 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				96F7486B1C87924C00E22DE1 /* MapboxDirections.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -74,11 +149,53 @@
 			name = Pods;
 			sourceTree = "<group>";
 		};
+		96F748251C878BDE00E22DE1 /* Swift */ = {
+			isa = PBXGroup;
+			children = (
+				DD6254531AE70C1700017857 /* AppDelegate.swift */,
+				DD6254551AE70C1700017857 /* ViewController.swift */,
+			);
+			name = Swift;
+			sourceTree = "<group>";
+		};
+		96F7482C1C878D9000E22DE1 /* MapboxDirections */ = {
+			isa = PBXGroup;
+			children = (
+				96F748431C878EE200E22DE1 /* MapboxDirections.swift */,
+				96F7482D1C878D9000E22DE1 /* MapboxDirections.h */,
+				96F7482F1C878D9000E22DE1 /* Info.plist */,
+			);
+			name = MapboxDirections;
+			path = MBDirections;
+			sourceTree = "<group>";
+		};
+		96F748501C87906D00E22DE1 /* Objective-C */ = {
+			isa = PBXGroup;
+			children = (
+				96EB889A1C87B0C200329BFE /* AppDelegate.h */,
+				96EB889B1C87B0C200329BFE /* AppDelegate.m */,
+				96EB889C1C87B0C200329BFE /* ViewController.h */,
+				96EB889D1C87B0C200329BFE /* ViewController.m */,
+			);
+			name = "Objective-C";
+			path = "../Example (Objective-C)";
+			sourceTree = "<group>";
+		};
+		96F748761C8793D900E22DE1 /* Supporting Files */ = {
+			isa = PBXGroup;
+			children = (
+				DD6254521AE70C1700017857 /* Info.plist */,
+				96F748771C87956300E22DE1 /* Launch Screen.storyboard */,
+				96F748521C87906D00E22DE1 /* main.m */,
+			);
+			name = "Supporting Files";
+			sourceTree = "<group>";
+		};
 		DD6254451AE70C1700017857 = {
 			isa = PBXGroup;
 			children = (
 				DD6254501AE70C1700017857 /* Directions Example */,
-				DD6254771AE70D1600017857 /* Mapbox Directions */,
+				96F7482C1C878D9000E22DE1 /* MapboxDirections */,
 				DDF1E8651BD8580800C40C78 /* Unit Tests */,
 				DD62544F1AE70C1700017857 /* Products */,
 				5B3D85980BD858C449447B5B /* Pods */,
@@ -89,8 +206,10 @@
 		DD62544F1AE70C1700017857 /* Products */ = {
 			isa = PBXGroup;
 			children = (
-				DD62544E1AE70C1700017857 /* Directions Example.app */,
+				DD62544E1AE70C1700017857 /* Example (Swift).app */,
 				DDF1E8641BD8580800C40C78 /* Unit Tests.xctest */,
+				96F7482B1C878D9000E22DE1 /* MapboxDirections.framework */,
+				96F7484F1C87906D00E22DE1 /* Example (Objective-C).app */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -98,27 +217,10 @@
 		DD6254501AE70C1700017857 /* Directions Example */ = {
 			isa = PBXGroup;
 			children = (
-				DD6254531AE70C1700017857 /* AppDelegate.swift */,
-				DD6254551AE70C1700017857 /* ViewController.swift */,
-				DD6254511AE70C1700017857 /* Supporting Files */,
+				96F748251C878BDE00E22DE1 /* Swift */,
+				96F748501C87906D00E22DE1 /* Objective-C */,
+				96F748761C8793D900E22DE1 /* Supporting Files */,
 			);
-			path = "Directions Example";
-			sourceTree = "<group>";
-		};
-		DD6254511AE70C1700017857 /* Supporting Files */ = {
-			isa = PBXGroup;
-			children = (
-				DD6254521AE70C1700017857 /* Info.plist */,
-			);
-			name = "Supporting Files";
-			sourceTree = "<group>";
-		};
-		DD6254771AE70D1600017857 /* Mapbox Directions */ = {
-			isa = PBXGroup;
-			children = (
-				DD6254731AE70CB700017857 /* MapboxDirections.swift */,
-			);
-			name = "Mapbox Directions";
 			path = "Directions Example";
 			sourceTree = "<group>";
 		};
@@ -133,22 +235,72 @@
 		};
 /* End PBXGroup section */
 
+/* Begin PBXHeadersBuildPhase section */
+		96F748281C878D9000E22DE1 /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				96F7482E1C878D9000E22DE1 /* MapboxDirections.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXHeadersBuildPhase section */
+
 /* Begin PBXNativeTarget section */
-		DD62544D1AE70C1700017857 /* Directions Example */ = {
+		96F7482A1C878D9000E22DE1 /* MapboxDirections */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = DD62546D1AE70C1700017857 /* Build configuration list for PBXNativeTarget "Directions Example" */;
+			buildConfigurationList = 96F7483C1C878D9100E22DE1 /* Build configuration list for PBXNativeTarget "MapboxDirections" */;
 			buildPhases = (
-				DD62544A1AE70C1700017857 /* Sources */,
-				DD62544B1AE70C1700017857 /* Frameworks */,
-				DD62544C1AE70C1700017857 /* Resources */,
+				96F748261C878D9000E22DE1 /* Sources */,
+				96F748271C878D9000E22DE1 /* Frameworks */,
+				96F748281C878D9000E22DE1 /* Headers */,
+				96F748291C878D9000E22DE1 /* Resources */,
 			);
 			buildRules = (
 			);
 			dependencies = (
 			);
-			name = "Directions Example";
+			name = MapboxDirections;
+			productName = MapboxDirections;
+			productReference = 96F7482B1C878D9000E22DE1 /* MapboxDirections.framework */;
+			productType = "com.apple.product-type.framework";
+		};
+		96F7484E1C87906D00E22DE1 /* Example (Objective-C) */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 96F748631C87906D00E22DE1 /* Build configuration list for PBXNativeTarget "Example (Objective-C)" */;
+			buildPhases = (
+				96F7484B1C87906D00E22DE1 /* Sources */,
+				96F7484C1C87906D00E22DE1 /* Frameworks */,
+				96F7484D1C87906D00E22DE1 /* Resources */,
+				96F748741C87925C00E22DE1 /* Embed Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				96F748731C87925C00E22DE1 /* PBXTargetDependency */,
+			);
+			name = "Example (Objective-C)";
+			productName = "Example (Objective-C)";
+			productReference = 96F7484F1C87906D00E22DE1 /* Example (Objective-C).app */;
+			productType = "com.apple.product-type.application";
+		};
+		DD62544D1AE70C1700017857 /* Example (Swift) */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = DD62546D1AE70C1700017857 /* Build configuration list for PBXNativeTarget "Example (Swift)" */;
+			buildPhases = (
+				DD62544A1AE70C1700017857 /* Sources */,
+				DD62544B1AE70C1700017857 /* Frameworks */,
+				DD62544C1AE70C1700017857 /* Resources */,
+				96F7486F1C87924C00E22DE1 /* Embed Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				96F7486E1C87924C00E22DE1 /* PBXTargetDependency */,
+			);
+			name = "Example (Swift)";
 			productName = "Directions Example";
-			productReference = DD62544E1AE70C1700017857 /* Directions Example.app */;
+			productReference = DD62544E1AE70C1700017857 /* Example (Swift).app */;
 			productType = "com.apple.product-type.application";
 		};
 		DDF1E8631BD8580800C40C78 /* Unit Tests */ = {
@@ -179,10 +331,16 @@
 			isa = PBXProject;
 			attributes = {
 				LastSwiftMigration = 0700;
-				LastSwiftUpdateCheck = 0700;
+				LastSwiftUpdateCheck = 0730;
 				LastUpgradeCheck = 0700;
 				ORGANIZATIONNAME = Mapbox;
 				TargetAttributes = {
+					96F7482A1C878D9000E22DE1 = {
+						CreatedOnToolsVersion = 7.3;
+					};
+					96F7484E1C87906D00E22DE1 = {
+						CreatedOnToolsVersion = 7.3;
+					};
 					DD62544D1AE70C1700017857 = {
 						CreatedOnToolsVersion = 6.3;
 					};
@@ -204,17 +362,35 @@
 			projectDirPath = "";
 			projectRoot = "";
 			targets = (
-				DD62544D1AE70C1700017857 /* Directions Example */,
+				DD62544D1AE70C1700017857 /* Example (Swift) */,
+				96F7484E1C87906D00E22DE1 /* Example (Objective-C) */,
+				96F7482A1C878D9000E22DE1 /* MapboxDirections */,
 				DDF1E8631BD8580800C40C78 /* Unit Tests */,
 			);
 		};
 /* End PBXProject section */
 
 /* Begin PBXResourcesBuildPhase section */
+		96F748291C878D9000E22DE1 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		96F7484D1C87906D00E22DE1 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				96F748791C87956300E22DE1 /* Launch Screen.storyboard in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		DD62544C1AE70C1700017857 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				96F748781C87956300E22DE1 /* Launch Screen.storyboard in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -276,13 +452,30 @@
 /* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
+		96F748261C878D9000E22DE1 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				96F748441C878EE200E22DE1 /* MapboxDirections.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		96F7484B1C87906D00E22DE1 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				96EB889F1C87B0C200329BFE /* ViewController.m in Sources */,
+				96EB889E1C87B0C200329BFE /* AppDelegate.m in Sources */,
+				96F748531C87906D00E22DE1 /* main.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		DD62544A1AE70C1700017857 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 				DD6254541AE70C1700017857 /* AppDelegate.swift in Sources */,
 				DD6254561AE70C1700017857 /* ViewController.swift in Sources */,
-				DD6254741AE70CB700017857 /* MapboxDirections.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -297,14 +490,93 @@
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
+		96F7486E1C87924C00E22DE1 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 96F7482A1C878D9000E22DE1 /* MapboxDirections */;
+			targetProxy = 96F7486D1C87924C00E22DE1 /* PBXContainerItemProxy */;
+		};
+		96F748731C87925C00E22DE1 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 96F7482A1C878D9000E22DE1 /* MapboxDirections */;
+			targetProxy = 96F748721C87925C00E22DE1 /* PBXContainerItemProxy */;
+		};
 		DDF1E86A1BD8580800C40C78 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
-			target = DD62544D1AE70C1700017857 /* Directions Example */;
+			target = DD62544D1AE70C1700017857 /* Example (Swift) */;
 			targetProxy = DDF1E8691BD8580800C40C78 /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 
 /* Begin XCBuildConfiguration section */
+		96F7483D1C878D9100E22DE1 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ENABLE_MODULES = YES;
+				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				INFOPLIST_FILE = "$(SRCROOT)/MBDirections/Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = com.mapbox.MapboxDirections;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Debug;
+		};
+		96F7483E1C878D9100E22DE1 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ENABLE_MODULES = YES;
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				INFOPLIST_FILE = "$(SRCROOT)/MBDirections/Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = com.mapbox.MapboxDirections;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Release;
+		};
+		96F748641C87906D00E22DE1 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ANALYZER_NONNULL = YES;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				EMBEDDED_CONTENT_CONTAINS_SWIFT = YES;
+				INFOPLIST_FILE = "$(SRCROOT)/Directions Example/Supporting Files/Info.plist";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.mapbox.Example--Objective-C-";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+			};
+			name = Debug;
+		};
+		96F748651C87906D00E22DE1 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ANALYZER_NONNULL = YES;
+				EMBEDDED_CONTENT_CONTAINS_SWIFT = YES;
+				INFOPLIST_FILE = "$(SRCROOT)/Directions Example/Supporting Files/Info.plist";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.mapbox.Example--Objective-C-";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+			};
+			name = Release;
+		};
 		DD62546B1AE70C1700017857 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -342,7 +614,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 8.3;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = iphoneos;
@@ -381,7 +653,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 8.3;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -392,8 +664,8 @@
 		DD62546E1AE70C1700017857 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
-				INFOPLIST_FILE = "Directions Example/Info.plist";
+				EMBEDDED_CONTENT_CONTAINS_SWIFT = YES;
+				INFOPLIST_FILE = "$(SRCROOT)/Directions Example/Supporting Files/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.mapbox.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -403,8 +675,8 @@
 		DD62546F1AE70C1700017857 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
-				INFOPLIST_FILE = "Directions Example/Info.plist";
+				EMBEDDED_CONTENT_CONTAINS_SWIFT = YES;
+				INFOPLIST_FILE = "$(SRCROOT)/Directions Example/Supporting Files/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.mapbox.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -439,6 +711,24 @@
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
+		96F7483C1C878D9100E22DE1 /* Build configuration list for PBXNativeTarget "MapboxDirections" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				96F7483D1C878D9100E22DE1 /* Debug */,
+				96F7483E1C878D9100E22DE1 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		96F748631C87906D00E22DE1 /* Build configuration list for PBXNativeTarget "Example (Objective-C)" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				96F748641C87906D00E22DE1 /* Debug */,
+				96F748651C87906D00E22DE1 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
 		DD6254491AE70C1700017857 /* Build configuration list for PBXProject "Directions Example" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
@@ -448,7 +738,7 @@
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		DD62546D1AE70C1700017857 /* Build configuration list for PBXNativeTarget "Directions Example" */ = {
+		DD62546D1AE70C1700017857 /* Build configuration list for PBXNativeTarget "Example (Swift)" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				DD62546E1AE70C1700017857 /* Debug */,

--- a/Directions Example.xcodeproj/xcshareddata/xcschemes/Directions Example.xcscheme
+++ b/Directions Example.xcodeproj/xcshareddata/xcschemes/Directions Example.xcscheme
@@ -15,8 +15,8 @@
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "DD62544D1AE70C1700017857"
-               BuildableName = "Directions Example.app"
-               BlueprintName = "Directions Example"
+               BuildableName = "Example (Swift).app"
+               BlueprintName = "Example (Swift)"
                ReferencedContainer = "container:Directions Example.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>
@@ -57,8 +57,8 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "DD62544D1AE70C1700017857"
-            BuildableName = "Directions Example.app"
-            BlueprintName = "Directions Example"
+            BuildableName = "Example (Swift).app"
+            BlueprintName = "Example (Swift)"
             ReferencedContainer = "container:Directions Example.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
@@ -80,8 +80,8 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "DD62544D1AE70C1700017857"
-            BuildableName = "Directions Example.app"
-            BlueprintName = "Directions Example"
+            BuildableName = "Example (Swift).app"
+            BlueprintName = "Example (Swift)"
             ReferencedContainer = "container:Directions Example.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
@@ -99,8 +99,8 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "DD62544D1AE70C1700017857"
-            BuildableName = "Directions Example.app"
-            BlueprintName = "Directions Example"
+            BuildableName = "Example (Swift).app"
+            BlueprintName = "Example (Swift)"
             ReferencedContainer = "container:Directions Example.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>

--- a/Directions Example/AppDelegate.h
+++ b/Directions Example/AppDelegate.h
@@ -1,0 +1,9 @@
+#import <UIKit/UIKit.h>
+
+@interface AppDelegate : UIResponder <UIApplicationDelegate>
+
+@property (strong, nonatomic) UIWindow *window;
+
+
+@end
+

--- a/Directions Example/AppDelegate.m
+++ b/Directions Example/AppDelegate.m
@@ -1,0 +1,19 @@
+#import "AppDelegate.h"
+#import "ViewController.h"
+
+@interface AppDelegate ()
+
+@end
+
+@implementation AppDelegate
+
+
+- (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions {
+    self.window = [[UIWindow alloc] initWithFrame:[[UIScreen mainScreen] bounds]];
+    self.window.rootViewController = [ViewController new];
+    [self.window makeKeyAndVisible];
+
+    return YES;
+}
+
+@end

--- a/Directions Example/Supporting Files/Info.plist
+++ b/Directions Example/Supporting Files/Info.plist
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>APPL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+	<key>LSRequiresIPhoneOS</key>
+	<true/>
+	<key>UILaunchStoryboardName</key>
+	<string>Launch Screen</string>
+	<key>UIRequiredDeviceCapabilities</key>
+	<array>
+		<string>armv7</string>
+	</array>
+	<key>UISupportedInterfaceOrientations</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+	<key>UISupportedInterfaceOrientations~ipad</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationPortraitUpsideDown</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+</dict>
+</plist>

--- a/Directions Example/Supporting Files/Launch Screen.storyboard
+++ b/Directions Example/Supporting Files/Launch Screen.storyboard
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="10115" systemVersion="15E39d" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" launchScreen="YES" useTraitCollections="YES" initialViewController="01J-lp-oVM">
+    <dependencies>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="10084"/>
+    </dependencies>
+    <scenes>
+        <!--View Controller-->
+        <scene sceneID="EHf-IW-A2E">
+            <objects>
+                <viewController id="01J-lp-oVM" sceneMemberID="viewController">
+                    <layoutGuides>
+                        <viewControllerLayoutGuide type="top" id="Llm-lL-Icb"/>
+                        <viewControllerLayoutGuide type="bottom" id="xb3-aO-Qok"/>
+                    </layoutGuides>
+                    <view key="view" contentMode="scaleToFill" id="Ze5-6b-2t3">
+                        <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <color key="backgroundColor" red="0.23137254900000001" green="0.69803921570000005" blue="0.81568627449999997" alpha="1" colorSpace="calibratedRGB"/>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="iYj-Kq-Ea1" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="53" y="375"/>
+        </scene>
+    </scenes>
+    <color key="tintColor" red="0.23137254900000001" green="0.69803921570000005" blue="0.81568627449999997" alpha="1" colorSpace="calibratedRGB"/>
+</document>

--- a/Directions Example/Supporting Files/main.m
+++ b/Directions Example/Supporting Files/main.m
@@ -1,0 +1,16 @@
+//
+//  main.m
+//  Example (Objective-C)
+//
+//  Created by Jason Wray on 3/2/16.
+//  Copyright © 2016 Mapbox. All rights reserved.
+//
+
+#import <UIKit/UIKit.h>
+#import "AppDelegate.h"
+
+int main(int argc, char * argv[]) {
+    @autoreleasepool {
+        return UIApplicationMain(argc, argv, nil, NSStringFromClass([AppDelegate class]));
+    }
+}

--- a/Directions Example/ViewController.h
+++ b/Directions Example/ViewController.h
@@ -1,0 +1,7 @@
+#import <UIKit/UIKit.h>
+
+@interface ViewController : UIViewController
+
+
+@end
+

--- a/Directions Example/ViewController.m
+++ b/Directions Example/ViewController.m
@@ -1,0 +1,52 @@
+@import UIKit;
+@import CoreLocation;
+@import MapboxDirections;
+
+#import "ViewController.h"
+
+// A Mapbox access token is required to use the Directions API.
+// https://www.mapbox.com/help/create-api-access-token/
+NSString *const MapboxAccessToken = @"<# your Mapbox access token #>";
+
+@interface ViewController ()
+
+@property (nonatomic) MBDirections *directions;
+
+@end
+
+@implementation ViewController
+
+- (void)viewDidLoad {
+    [super viewDidLoad];
+
+    NSAssert(![MapboxAccessToken isEqualToString:@"<# your Mapbox access token #>"], @"You must enter your Mapbox access token at the top of this view controller.");
+
+    UILabel *label = [[UILabel alloc] initWithFrame:CGRectMake((self.view.bounds.size.width - 200) / 2, (self.view.bounds.size.height - 40) / 2, 200, 40)];
+    label.autoresizingMask = UIViewAutoresizingFlexibleLeftMargin | UIViewAutoresizingFlexibleTopMargin;
+    label.textColor = [UIColor whiteColor];
+    label.textAlignment = NSTextAlignmentCenter;
+    label.text = @"Check the console.";
+    [self.view addSubview:label];
+
+    CLLocationCoordinate2D origin = CLLocationCoordinate2DMake(38.9131752, -77.0324047);
+    CLLocationCoordinate2D destination = CLLocationCoordinate2DMake(38.8977, -77.0365);
+
+    MBDirectionsRequest *request = [[MBDirectionsRequest alloc] initWithOriginCoordinate:origin destinationCoordinate:destination];
+
+    self.directions = [[MBDirections alloc] initWithRequest:request accessToken:MapboxAccessToken];
+
+    [self.directions calculateDirectionsWithCompletionHandler:^(MBDirectionsResponse *response, NSError *error) {
+        MBRoute *route = response.routes.firstObject;
+        if (route) {
+            NSLog(@"Route summary:");
+            NSLog(@"Distance: %.2f meters (%lu route steps) after %.2f minutes", route.distance, (unsigned long)route.steps.count, route.expectedTravelTime / 60);
+            for (MBRouteStep *step in route.steps) {
+                NSLog(@"  %@ in %.f meters", step.instructions, step.distance);
+            }
+        } else {
+            NSLog(@"Error calculating directions: %@", error);
+        }
+    }];
+}
+
+@end

--- a/Directions Example/ViewController.swift
+++ b/Directions Example/ViewController.swift
@@ -1,5 +1,6 @@
 import UIKit
 import CoreLocation
+import MapboxDirections
 
 // A Mapbox access token is required to use the Directions API.
 // https://www.mapbox.com/help/create-api-access-token/
@@ -12,7 +13,7 @@ class ViewController: UIViewController {
     override func viewDidAppear(animated: Bool) {
         super.viewDidAppear(animated)
 
-        assert(MapboxAccessToken != "<# your Mapbox access token #>", "You must enter your Mapbox access token at the top of the view controller in order for this demo to work.")
+        assert(MapboxAccessToken != "<# your Mapbox access token #>", "You must enter your Mapbox access token at the top of this view controller.")
 
         view.addSubview({ [unowned self] in
             let label = UILabel(frame: CGRect(x: (self.view.bounds.size.width - 200) / 2,
@@ -24,21 +25,21 @@ class ViewController: UIViewController {
             label.textAlignment = .Center
             label.text = "Check the console"
             return label
-            }())
+        }())
 
-        let mb = CLLocationCoordinate2D(latitude: 38.9131752, longitude: -77.0324047)
-        let wh = CLLocationCoordinate2D(latitude: 38.8977, longitude: -77.0365)
+        let origin = CLLocationCoordinate2D(latitude: 38.9131752, longitude: -77.0324047)
+        let destination = CLLocationCoordinate2D(latitude: 38.8977, longitude: -77.0365)
 
-        let request = MBDirectionsRequest(sourceCoordinate: mb, destinationCoordinate: wh)
+        let request = MBDirectionsRequest(sourceCoordinate: origin, destinationCoordinate: destination)
 
         directions = MBDirections(request: request, accessToken: MapboxAccessToken)
 
         directions!.calculateDirectionsWithCompletionHandler { (response, error) in
             if let route = response?.routes.first {
                 print("Route summary:")
-                print("Distance: \(route.distance) meters (\(route.steps.count) route steps) in \(route.expectedTravelTime / 60) minutes")
+                print("Distance: \(route.distance) meters (\(route.steps.count) route steps) after \(route.expectedTravelTime / 60) minutes")
                 for step in route.steps {
-                    print("\(step.instructions) \(step.distance) meters")
+                    print("  \(step.instructions) in \(step.distance) meters")
                 }
             } else {
                 print("Error calculating directions: \(error)")

--- a/Directions Example/ViewController.swift
+++ b/Directions Example/ViewController.swift
@@ -12,6 +12,8 @@ class ViewController: UIViewController {
     override func viewDidAppear(animated: Bool) {
         super.viewDidAppear(animated)
 
+        assert(MapboxAccessToken != "<# your Mapbox access token #>", "You must enter your Mapbox access token at the top of the view controller in order for this demo to work.")
+
         view.addSubview({ [unowned self] in
             let label = UILabel(frame: CGRect(x: (self.view.bounds.size.width - 200) / 2,
                 y: (self.view.bounds.size.height - 40) / 2,

--- a/MBDirections/Info.plist
+++ b/MBDirections/Info.plist
@@ -13,31 +13,14 @@
 	<key>CFBundleName</key>
 	<string>$(PRODUCT_NAME)</string>
 	<key>CFBundlePackageType</key>
-	<string>APPL</string>
+	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
 	<string>1.0</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>1</string>
-	<key>LSRequiresIPhoneOS</key>
-	<true/>
-	<key>UIRequiredDeviceCapabilities</key>
-	<array>
-		<string>armv7</string>
-	</array>
-	<key>UISupportedInterfaceOrientations</key>
-	<array>
-		<string>UIInterfaceOrientationPortrait</string>
-		<string>UIInterfaceOrientationLandscapeLeft</string>
-		<string>UIInterfaceOrientationLandscapeRight</string>
-	</array>
-	<key>UISupportedInterfaceOrientations~ipad</key>
-	<array>
-		<string>UIInterfaceOrientationPortrait</string>
-		<string>UIInterfaceOrientationPortraitUpsideDown</string>
-		<string>UIInterfaceOrientationLandscapeLeft</string>
-		<string>UIInterfaceOrientationLandscapeRight</string>
-	</array>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<key>NSPrincipalClass</key>
+	<string></string>
 </dict>
 </plist>

--- a/MBDirections/MapboxDirections.h
+++ b/MBDirections/MapboxDirections.h
@@ -1,0 +1,5 @@
+@import UIKit;
+
+FOUNDATION_EXPORT double MapboxDirectionsVersionNumber;
+
+FOUNDATION_EXPORT const unsigned char MapboxDirectionsVersionString[];

--- a/MBDirections/MapboxDirections.swift
+++ b/MBDirections/MapboxDirections.swift
@@ -9,7 +9,7 @@ internal typealias JSON = [String: AnyObject]
 
 // MARK: - Point
 
-public class MBPoint {
+public class MBPoint: NSObject {
 
     public let name: String?
     public let coordinate: CLLocationCoordinate2D
@@ -23,7 +23,7 @@ public class MBPoint {
 
 // MARK: - ETA Response
 
-public class MBETAResponse {
+public class MBETAResponse: NSObject {
 
     public let sourceCoordinate: CLLocationCoordinate2D
     public let waypointCoordinates: [CLLocationCoordinate2D]
@@ -41,7 +41,7 @@ public class MBETAResponse {
 
 // MARK: - Step
 
-public class MBRouteStep {
+public class MBRouteStep: NSObject {
 
     public enum Direction: String {
         case N = "N"
@@ -115,7 +115,7 @@ public class MBRouteStep {
 
 // MARK: - Route
 
-public class MBRoute {
+public class MBRoute: NSObject {
 
     //    var polyline: MKPolyline! { get }
     public let steps: [MBRouteStep]!
@@ -164,7 +164,7 @@ public class MBRoute {
 
 // MARK: - Request
 
-public class MBDirectionsRequest {
+public class MBDirectionsRequest: NSObject {
 
     public enum MBDirectionsTransportType: String {
         case Automobile = "mapbox.driving"
@@ -191,6 +191,10 @@ public class MBDirectionsRequest {
 
     //    class func isDirectionsRequestURL
     //    func initWithContentsOfURL
+
+    public convenience init(originCoordinate: CLLocationCoordinate2D, destinationCoordinate: CLLocationCoordinate2D) {
+        self.init(sourceCoordinate: originCoordinate, waypointCoordinates: [], destinationCoordinate: destinationCoordinate)
+    }
 
     public init(sourceCoordinate: CLLocationCoordinate2D, waypointCoordinates: [CLLocationCoordinate2D] = [], destinationCoordinate: CLLocationCoordinate2D) {
         self.sourceCoordinate = sourceCoordinate
@@ -220,7 +224,7 @@ public class MBDirectionsRequest {
 
 // MARK: - Directions Response
 
-public class MBDirectionsResponse {
+public class MBDirectionsResponse: NSObject {
 
     public let sourceCoordinate: CLLocationCoordinate2D
     public let waypointCoordinates: [CLLocationCoordinate2D]


### PR DESCRIPTION
**Changes**
- Adds `NSObject` to every public class in MapboxDirections.swift.
- Adds a new ObjC target to the Xcode project and moves the original Swift example to its own target.
- Adds a MapboxDirections.framework target that the two example targets bring in.
- Reorganizes the repo — moves MapboxDirections.swift to the MBDirections folder.
- Asserts that the access token has been changed (if not properly set).

**Issues**
- The initializer for `MBDirectionsRequest` will not automatically bridge to ObjC.
 -  `waypointCoordinates: [CLLocationCoordinate2D]` is the problem.
 - Temporarily created another initializer that ignores waypoints.
 - ... but this new initializer needs to be differently named, so that the compiler won't complain about ambiguity when you leave out a property when you're initializing in Swift.
- Logging output to console is meh, but acceptable for now.
- Tests need to be updated for the new project structure.

Will need to solve the initializer bridging problem and minimize disruption before this can be merged.

/cc @1ec5 