### PR TITLE
Make MBRoute.geometry non-optional again

### DIFF
--- a/MapboxDirections/MBDirectionsResponse.swift
+++ b/MapboxDirections/MBDirectionsResponse.swift
@@ -35,7 +35,7 @@ public class MBRoute {
     public let profileIdentifier: String
 
     // Mapbox-specific stuff
-    public let geometry: [CLLocationCoordinate2D]?
+    public let geometry: [CLLocationCoordinate2D]
 
     public let source: MBPoint
     public let waypoints: [MBPoint]
@@ -61,7 +61,7 @@ public class MBRoute {
         }
         distance = json["distance"] as! Double
         expectedTravelTime = json["duration"] as! Double
-        geometry = decodePolyline(json["geometry"] as! String, precision: 1e6)
+        geometry = decodePolyline(json["geometry"] as! String, precision: 1e6)!
     }
 }
 

--- a/MapboxDirectionsTests/MapboxDirectionsTests.swift
+++ b/MapboxDirectionsTests/MapboxDirectionsTests.swift
@@ -39,12 +39,12 @@ class MapboxDirectionsTests: XCTestCase {
         }
         
         XCTAssertEqual(routes.count, 2)
-        XCTAssertEqual(routes.first!.geometry!.count, 28268)
+        XCTAssertEqual(routes.first!.geometry.count, 28268)
         
         // confirming actual decoded values is important because the Directions API
         // uses an atypical precision level for polyline encoding
-        XCTAssertEqual(round(routes.first!.geometry!.first!.latitude), 38)
-        XCTAssertEqual(round(routes.first!.geometry!.first!.longitude), -122)
+        XCTAssertEqual(round(routes.first!.geometry.first!.latitude), 38)
+        XCTAssertEqual(round(routes.first!.geometry.first!.longitude), -122)
         XCTAssertEqual(routes.first!.legs.count, 1)
         XCTAssertEqual(routes.first!.legs.first!.steps.count, 136)
         XCTAssertEqual(routes.first!.legs.first!.steps[24].distance, 106_258)


### PR DESCRIPTION
#27 made `MBRoute.geometry` optional, but a route without geometry isn’t much of a route at all. If polyline decoding fails, that means the server returned malformed output. Crash on malformed output.

In the future, we’ll make the library handle malformed output more gracefully using Swift errors, but until the codebase stabilizes somewhat, we’ll play with fire in the form of implicitly unwrapped optionals.

/cc @tmcw