### PR TITLE
Convert Podfile to individual targets for CocoaPods 1.0.0

### DIFF
--- a/MapboxDirections.xcodeproj/project.pbxproj
+++ b/MapboxDirections.xcodeproj/project.pbxproj
@@ -7,10 +7,11 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		13135F3C4F08D93F939F83A2 /* Pods_Directions_Example.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 82C35F9E681FA317BAF09555 /* Pods_Directions_Example.framework */; };
+		570CFC8E96639816C066DF77 /* Pods_MapboxDirections.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CC5E2BCA5358EB2A2D5BF590 /* Pods_MapboxDirections.framework */; };
 		8543D22E59F4F058585E18B9 /* Pods_MapboxDirectionsTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 72B856631C2DD5B041A03A48 /* Pods_MapboxDirectionsTests.framework */; };
 		910EA7231CB5734F00858D31 /* driving_dc_polyline.json in Resources */ = {isa = PBXBuildFile; fileRef = 910EA7221CB5734F00858D31 /* driving_dc_polyline.json */; };
 		9151CBAA1CB5A36C006CF17B /* Polyline.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 910EA7241CB5917000858D31 /* Polyline.framework */; };
-		BB44F9743C24BD97DFD53E9F /* Pods.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 779CA65749150F5A75B46628 /* Pods.framework */; };
 		DA2133B21CAEEE3200AA2594 /* RequestKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DA2133B11CAEEE3200AA2594 /* RequestKit.framework */; };
 		DA2133B31CAEEFE100AA2594 /* MapboxDirections.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DA6C9D881CAE442B00094FBC /* MapboxDirections.framework */; };
 		DA2E03E91CB0E0B000D1269A /* MBDirectionsResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA2E03E81CB0E0B000D1269A /* MBDirectionsResponse.swift */; };
@@ -53,15 +54,17 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
-		371BFE7855E3EA8B44CA2B5F /* Pods_Unit_Tests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Unit_Tests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		177D9C1DCAACF836A954B9C3 /* Pods-Directions Example.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Directions Example.release.xcconfig"; path = "Pods/Target Support Files/Pods-Directions Example/Pods-Directions Example.release.xcconfig"; sourceTree = "<group>"; };
+		2F973BBA1EF00AFB5FD18C4B /* Pods-MapboxDirections.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-MapboxDirections.debug.xcconfig"; path = "Pods/Target Support Files/Pods-MapboxDirections/Pods-MapboxDirections.debug.xcconfig"; sourceTree = "<group>"; };
+		3772BE3FEE633B85D5960AA2 /* Pods-Directions Example.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Directions Example.debug.xcconfig"; path = "Pods/Target Support Files/Pods-Directions Example/Pods-Directions Example.debug.xcconfig"; sourceTree = "<group>"; };
+		59B2D6267FC5F8E0E605D6AF /* Pods-MapboxDirections.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-MapboxDirections.release.xcconfig"; path = "Pods/Target Support Files/Pods-MapboxDirections/Pods-MapboxDirections.release.xcconfig"; sourceTree = "<group>"; };
 		72B856631C2DD5B041A03A48 /* Pods_MapboxDirectionsTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_MapboxDirectionsTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		779CA65749150F5A75B46628 /* Pods.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		78F47212D6DC575EFAC36509 /* Pods-MapboxDirectionsTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-MapboxDirectionsTests.release.xcconfig"; path = "Pods/Target Support Files/Pods-MapboxDirectionsTests/Pods-MapboxDirectionsTests.release.xcconfig"; sourceTree = "<group>"; };
+		82C35F9E681FA317BAF09555 /* Pods_Directions_Example.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Directions_Example.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		910EA7221CB5734F00858D31 /* driving_dc_polyline.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = driving_dc_polyline.json; sourceTree = "<group>"; };
 		910EA7241CB5917000858D31 /* Polyline.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Polyline.framework; path = "../../Library/Developer/Xcode/DerivedData/MapboxDirections-cxcrsxhcoorbtxaohfcuxrgxzrsg/Build/Products/Debug-iphonesimulator/Polyline.framework"; sourceTree = "<group>"; };
-		A338BDE4A863FFF749998470 /* Pods.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = Pods.debug.xcconfig; path = "Pods/Target Support Files/Pods/Pods.debug.xcconfig"; sourceTree = "<group>"; };
 		B2FF88ACFEC9E7E276EF93DA /* Pods-MapboxDirectionsTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-MapboxDirectionsTests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-MapboxDirectionsTests/Pods-MapboxDirectionsTests.debug.xcconfig"; sourceTree = "<group>"; };
-		D4657820F4366F9DB1C432FB /* Pods-Unit Tests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Unit Tests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-Unit Tests/Pods-Unit Tests.debug.xcconfig"; sourceTree = "<group>"; };
+		CC5E2BCA5358EB2A2D5BF590 /* Pods_MapboxDirections.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_MapboxDirections.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		DA2133B11CAEEE3200AA2594 /* RequestKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = RequestKit.framework; path = "Pods/../build/Debug-iphoneos/RequestKit.framework"; sourceTree = "<group>"; };
 		DA2E03E81CB0E0B000D1269A /* MBDirectionsResponse.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MBDirectionsResponse.swift; sourceTree = "<group>"; };
 		DA2E03EA1CB0E13D00D1269A /* MBDirectionsRequest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MBDirectionsRequest.swift; sourceTree = "<group>"; };
@@ -76,13 +79,11 @@
 		DA6C9DB11CAECA0E00094FBC /* Fixture.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Fixture.swift; sourceTree = "<group>"; };
 		DAAA48291CACF99B0084F5B8 /* MBDirectionsConfiguration.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MBDirectionsConfiguration.swift; sourceTree = "<group>"; };
 		DAAA482B1CAD00AF0084F5B8 /* MBDirectionsRouter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MBDirectionsRouter.swift; sourceTree = "<group>"; };
-		DC75FB1E8F81F45AA5FDEACD /* Pods.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = Pods.release.xcconfig; path = "Pods/Target Support Files/Pods/Pods.release.xcconfig"; sourceTree = "<group>"; };
 		DD62544E1AE70C1700017857 /* Directions Example.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "Directions Example.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		DD6254521AE70C1700017857 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		DD6254531AE70C1700017857 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		DD6254551AE70C1700017857 /* ViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewController.swift; sourceTree = "<group>"; };
 		DD6254731AE70CB700017857 /* MBDirections.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MBDirections.swift; sourceTree = "<group>"; };
-		EE172AE7D4B472E6B85700BA /* Pods-Unit Tests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Unit Tests.release.xcconfig"; path = "Pods/Target Support Files/Pods-Unit Tests/Pods-Unit Tests.release.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -92,6 +93,7 @@
 			files = (
 				9151CBAA1CB5A36C006CF17B /* Polyline.framework in Frameworks */,
 				DA2133B21CAEEE3200AA2594 /* RequestKit.framework in Frameworks */,
+				570CFC8E96639816C066DF77 /* Pods_MapboxDirections.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -109,7 +111,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				DA2133B31CAEEFE100AA2594 /* MapboxDirections.framework in Frameworks */,
-				BB44F9743C24BD97DFD53E9F /* Pods.framework in Frameworks */,
+				13135F3C4F08D93F939F83A2 /* Pods_Directions_Example.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -121,9 +123,9 @@
 			children = (
 				910EA7241CB5917000858D31 /* Polyline.framework */,
 				DA2133B11CAEEE3200AA2594 /* RequestKit.framework */,
-				371BFE7855E3EA8B44CA2B5F /* Pods_Unit_Tests.framework */,
-				779CA65749150F5A75B46628 /* Pods.framework */,
 				72B856631C2DD5B041A03A48 /* Pods_MapboxDirectionsTests.framework */,
+				82C35F9E681FA317BAF09555 /* Pods_Directions_Example.framework */,
+				CC5E2BCA5358EB2A2D5BF590 /* Pods_MapboxDirections.framework */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -131,12 +133,12 @@
 		5B3D85980BD858C449447B5B /* Pods */ = {
 			isa = PBXGroup;
 			children = (
-				D4657820F4366F9DB1C432FB /* Pods-Unit Tests.debug.xcconfig */,
-				EE172AE7D4B472E6B85700BA /* Pods-Unit Tests.release.xcconfig */,
-				A338BDE4A863FFF749998470 /* Pods.debug.xcconfig */,
-				DC75FB1E8F81F45AA5FDEACD /* Pods.release.xcconfig */,
 				B2FF88ACFEC9E7E276EF93DA /* Pods-MapboxDirectionsTests.debug.xcconfig */,
 				78F47212D6DC575EFAC36509 /* Pods-MapboxDirectionsTests.release.xcconfig */,
+				2F973BBA1EF00AFB5FD18C4B /* Pods-MapboxDirections.debug.xcconfig */,
+				59B2D6267FC5F8E0E605D6AF /* Pods-MapboxDirections.release.xcconfig */,
+				3772BE3FEE633B85D5960AA2 /* Pods-Directions Example.debug.xcconfig */,
+				177D9C1DCAACF836A954B9C3 /* Pods-Directions Example.release.xcconfig */,
 			);
 			name = Pods;
 			sourceTree = "<group>";
@@ -250,10 +252,12 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = DA6C9DA01CAE442B00094FBC /* Build configuration list for PBXNativeTarget "MapboxDirections" */;
 			buildPhases = (
+				E4F58AFE16C929A75F6A3D5E /* Check Pods Manifest.lock */,
 				DA6C9D831CAE442B00094FBC /* Sources */,
 				DA6C9D841CAE442B00094FBC /* Frameworks */,
 				DA6C9D851CAE442B00094FBC /* Headers */,
 				DA6C9D861CAE442B00094FBC /* Resources */,
+				1F5749E9C9566D43B36C2CDA /* Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -376,6 +380,21 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
+		1F5749E9C9566D43B36C2CDA /* Copy Pods Resources */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "Copy Pods Resources";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-MapboxDirections/Pods-MapboxDirections-resources.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
 		3738FE126F24DA919402B82B /* Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
@@ -403,10 +422,25 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods/Pods-resources.sh\"\n";
+			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-Directions Example/Pods-Directions Example-resources.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 		CD3E7908B6FFC5E29B8A7975 /* Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "Check Pods Manifest.lock";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [[ $? != 0 ]] ; then\n    cat << EOM\nerror: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\nEOM\n    exit 1\nfi\n";
+			showEnvVarsInLog = 0;
+		};
+		E4F58AFE16C929A75F6A3D5E /* Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -448,7 +482,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods/Pods-frameworks.sh\"\n";
+			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-Directions Example/Pods-Directions Example-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 		F8FFBD07FA3BEE0E45268CFB /* Copy Pods Resources */ = {
@@ -523,6 +557,7 @@
 /* Begin XCBuildConfiguration section */
 		DA6C9DA11CAE442B00094FBC /* Debug */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 2F973BBA1EF00AFB5FD18C4B /* Pods-MapboxDirections.debug.xcconfig */;
 			buildSettings = {
 				CLANG_ANALYZER_NONNULL = YES;
 				CURRENT_PROJECT_VERSION = 1;
@@ -544,6 +579,7 @@
 		};
 		DA6C9DA21CAE442B00094FBC /* Release */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 59B2D6267FC5F8E0E605D6AF /* Pods-MapboxDirections.release.xcconfig */;
 			buildSettings = {
 				CLANG_ANALYZER_NONNULL = YES;
 				CURRENT_PROJECT_VERSION = 1;
@@ -675,7 +711,7 @@
 		};
 		DD62546E1AE70C1700017857 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = A338BDE4A863FFF749998470 /* Pods.debug.xcconfig */;
+			baseConfigurationReference = 3772BE3FEE633B85D5960AA2 /* Pods-Directions Example.debug.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				INFOPLIST_FILE = "Directions Example/Info.plist";
@@ -687,7 +723,7 @@
 		};
 		DD62546F1AE70C1700017857 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = DC75FB1E8F81F45AA5FDEACD /* Pods.release.xcconfig */;
+			baseConfigurationReference = 177D9C1DCAACF836A954B9C3 /* Pods-Directions Example.release.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				INFOPLIST_FILE = "Directions Example/Info.plist";

--- a/Podfile
+++ b/Podfile
@@ -1,9 +1,20 @@
 platform :ios, '8.0'
 use_frameworks!
 
-pod 'NBNRequestKit', :git => 'https://github.com/1ec5/RequestKit.git', :branch => 'mapbox-podspec'
-pod 'Polyline', '~> 3.0'
+def shared_pods
+  pod 'NBNRequestKit', :git => 'https://github.com/1ec5/RequestKit.git', :branch => 'mapbox-podspec'
+  pod 'Polyline', '~> 3.0'
+end
+
+target 'MapboxDirections' do
+  shared_pods
+end
 
 target 'MapboxDirectionsTests' do
   pod 'Nocilla'
+  shared_pods
+end
+
+target 'Directions Example' do
+    shared_pods
 end


### PR DESCRIPTION
Moves the Podfile to individually named targets, as defined in the Xcode project. This is required for [CocoaPods 1.0.0](http://blog.cocoapods.org/CocoaPods-1.0/).

/cc @1ec5