### PR TITLE
Update v5 API

### DIFF
--- a/MapboxDirections/MBDirections.swift
+++ b/MapboxDirections/MBDirections.swift
@@ -8,9 +8,9 @@ internal typealias JSON = [String: AnyObject]
 public let MBDirectionsErrorDomain = "MBDirectionsErrorDomain"
 
 public enum MBDirectionsErrorCode: UInt {
-    case DirectionsNotFound = 200
-    case ProfileNotFound = 404
-    case InvalidInput = 422
+    case DirectionsNotFound = 200 // code = NoRoute, NoSegment
+    case ProfileNotFound = 404 // code = ProfileNotFound
+    case InvalidInput = 422 // code = InvalidInput
 }
 
 public class MBPoint {

--- a/MapboxDirections/MBDirectionsRequest.swift
+++ b/MapboxDirections/MBDirectionsRequest.swift
@@ -8,7 +8,7 @@ public class MBDirectionsRequest {
     }
     public var version: APIVersion = .Five
     
-    public enum MBDirectionsTransportType: String {
+    public enum TransportType: String {
         case Automobile = "mapbox/driving"
         case Walking    = "mapbox/walking"
         case Cycling    = "mapbox/cycling"
@@ -20,15 +20,15 @@ public class MBDirectionsRequest {
     public let waypointCoordinates: [CLLocationCoordinate2D]
     public let destinationCoordinate: CLLocationCoordinate2D
     public var requestsAlternateRoutes = false
-    public var transportType: MBDirectionsTransportType {
+    public var transportType: TransportType {
         get {
-            return MBDirectionsTransportType(rawValue: profileIdentifier) ?? .Automobile
+            return TransportType(rawValue: profileIdentifier) ?? .Automobile
         }
         set {
             profileIdentifier = newValue.rawValue
         }
     }
-    public var profileIdentifier: String = MBDirectionsTransportType.Automobile.rawValue
+    public var profileIdentifier: String = TransportType.Automobile.rawValue
     //    var departureDate: NSDate!
     //    var arrivalDate: NSDate!
 

--- a/MapboxDirections/MBDirectionsResponse.swift
+++ b/MapboxDirections/MBDirectionsResponse.swift
@@ -29,8 +29,8 @@ public class MBRoute {
 //    var advisoryNotices: [AnyObject]! { get }
     public let distance: CLLocationDistance
     public let expectedTravelTime: NSTimeInterval
-    public var transportType: MBDirectionsRequest.MBDirectionsTransportType {
-        return MBDirectionsRequest.MBDirectionsTransportType(rawValue: profileIdentifier) ?? .Automobile
+    public var transportType: MBDirectionsRequest.TransportType {
+        return MBDirectionsRequest.TransportType(rawValue: profileIdentifier) ?? .Automobile
     }
     public let profileIdentifier: String
 
@@ -75,8 +75,8 @@ public class MBRouteLeg {
 //    var advisoryNotices: [AnyObject]! { get }
     public let distance: CLLocationDistance
     public let expectedTravelTime: NSTimeInterval
-    public var transportType: MBDirectionsRequest.MBDirectionsTransportType {
-        return MBDirectionsRequest.MBDirectionsTransportType(rawValue: profileIdentifier) ?? .Automobile
+    public var transportType: MBDirectionsRequest.TransportType {
+        return MBDirectionsRequest.TransportType(rawValue: profileIdentifier) ?? .Automobile
     }
     public let profileIdentifier: String
 
@@ -97,6 +97,27 @@ public class MBRouteLeg {
 }
 
 public class MBRouteStep {
+    public enum TransportType: String {
+        // mapbox/driving
+        case Automobile = "driving"
+        case Ferry = "ferry"
+        case MovableBridge = "moveable bridge"
+        case Inaccessible = "unaccessible"
+        
+        // mapbox/walking
+        case Walking = "walking"
+        // case Ferry = "ferry"
+        // case Inaccessible = "unaccessible"
+        
+        // mapbox/cycling
+        case Cycling = "cycling"
+        // case Walking = "walking"
+        // case Ferry = "ferry"
+        case Train = "train"
+        // case MovableBridge = "moveable bridge"
+        // case Inaccessible = "unaccessible"
+    }
+    
     public enum ManeuverType: String {
         case Turn = "turn"
         case PassNameChange = "new name"
@@ -156,7 +177,7 @@ public class MBRouteStep {
     public let instructions: String
     //    var notice: String! { get }
     public let distance: CLLocationDistance
-    public let transportType: MBDirectionsRequest.MBDirectionsTransportType
+    public let transportType: TransportType?
     public let profileIdentifier: String
 
     // Mapbox-specific stuff
@@ -172,11 +193,8 @@ public class MBRouteStep {
 
     internal init(json: JSON, profileIdentifier: String, version: MBDirectionsRequest.APIVersion) {
         self.profileIdentifier = profileIdentifier
-        if let mode = json["mode"] as? String {
-            transportType = MBDirectionsRequest.MBDirectionsTransportType(rawValue: "mapbox/\(mode)") ?? .Automobile
-        } else {
-            transportType = MBDirectionsRequest.MBDirectionsTransportType(rawValue: profileIdentifier) ?? .Automobile
-        }
+        // v4 supplies no mode in the arrival step.
+        transportType = TransportType(rawValue: json["mode"] as? String ?? "")
         
         let maneuver = json["maneuver"] as! JSON
         instructions = maneuver["instruction"] as! String

--- a/MapboxDirections/MBDirectionsResponse.swift
+++ b/MapboxDirections/MBDirectionsResponse.swift
@@ -87,12 +87,22 @@ public class MBRouteLeg {
         self.source = source
         self.destination = destination
         self.profileIdentifier = profileIdentifier
-        steps = (json["steps"] as? [JSON] ?? []).map {
-            MBRouteStep(json: $0, profileIdentifier: profileIdentifier, version: version)
+        let name = json["summary"] as? String
+        var stepNamesByDistance: [String: CLLocationDistance] = [:]
+        steps = (json["steps"] as? [JSON] ?? []).map { json in
+            let step = MBRouteStep(json: json, profileIdentifier: profileIdentifier, version: version)
+            // If no summary is provided for some reason, synthesize one out of the two names that make up the longest cumulative distance along the route.
+            if let name = name where !name.isEmpty {
+                if let stepName = step.name where !stepName.isEmpty {
+                    stepNamesByDistance[stepName] = (stepNamesByDistance[stepName] ?? 0) + step.distance
+                }
+            }
+            return step
         }
         distance = json["distance"] as! Double
         expectedTravelTime = json["duration"] as! Double
-        name = json["summary"] as! String
+        let longestNames = Array(stepNamesByDistance.sort { $0.1 > $1.1 }.prefix(2))
+        self.name = name ?? longestNames.map { $0.0 }.joinWithSeparator(" – ")
     }
 }
 

--- a/MapboxDirections/MBDirectionsResponse.swift
+++ b/MapboxDirections/MBDirectionsResponse.swift
@@ -129,27 +129,28 @@ public class MBRouteStep {
     }
     
     public enum ManeuverType: String {
+        case Depart = "depart"
         case Turn = "turn"
+        case Continue = "continue"
         case PassNameChange = "new name"
-        case PassWaypoint = "waypoint"
-        case PassInformationalPoint = "suppressed"
         case Merge = "merge"
         case TakeRamp = "ramp"
         case ReachFork = "fork"
         case ReachEnd = "end of road"
-        case EnterRoundabout = "enter roundabout"
-        case ExitRoundabout = "exit roundabout"
-        
-        // Undocumented but present in API responses
-        case Depart = "depart"
+        case TakeRoundabout = "roundabout"
+        case HeedWarning = "notification"
         case Arrive = "arrive"
-        case Continue = "continue"
+        
+        // Compatibility with v4
+        case PassWaypoint = "waypoint"
         
         init?(v4RawValue: String) {
             let rawValue: String
             switch v4RawValue {
             case "bear right", "turn right", "sharp right", "sharp left", "turn left", "bear left", "u-turn":
                 rawValue = "turn"
+            case "enter roundabout":
+                rawValue = "roundabout"
             default:
                 rawValue = v4RawValue
             }

--- a/MapboxDirections/MBDirectionsRouter.swift
+++ b/MapboxDirections/MBDirectionsRouter.swift
@@ -83,10 +83,10 @@ internal enum MBDirectionsRouter: Router {
             }
             return params
             
-        case .V5(_, _, let waypoints, let includeAlternative, let geometryFormat, let overviewGranularity, let includeSteps, let allowPointUTurns):
+        case .V5(_, _, let waypoints, let includeAlternative, let geometryFormat, let overviewGranularity, let includeSteps, let allowUTurnAtWaypoint):
             var params: [String: String] = [:]
             if let includeAlternative = includeAlternative {
-                params["alternative"] = String(includeAlternative)
+                params["alternatives"] = String(includeAlternative)
             }
             let hasHeadings = !(waypoints.flatMap { $0.heading }.isEmpty)
             if hasHeadings {
@@ -109,8 +109,8 @@ internal enum MBDirectionsRouter: Router {
             if let includeSteps = includeSteps {
                 params["steps"] = String(includeSteps)
             }
-            if let allowPointUTurns = allowPointUTurns {
-                params["uturns"] = String(allowPointUTurns)
+            if let allowUTurnAtWaypoint = allowUTurnAtWaypoint {
+                params["continue_straight"] = String(allowUTurnAtWaypoint)
             }
             return params
         }


### PR DESCRIPTION
This PR reacts to various changes to the v5 API made over the past few weeks:

* Updated `ManeuverType` values.
* A request has only one transport type, corresponding to the profile, but for every request, each step may have a different, more granular transport type. So now an `MBRouteStep`’s `transportType` has a distinct datatype. The `transportType` property matters particularly when the `maneuverType` is `HeedWarning`.
* Updated v5 URL parameters.
* v5 route legs currently lack route summaries, so here I’m synthesizing them using logic similar to what would be done on the server side. This code can be very expensive, so I hope to remove it as soon as possible.

/cc @karenzshea @bsudekum @freenerd