### PR TITLE
Update maneuver types

### DIFF
--- a/MapboxDirections/MBDirectionsResponse.swift
+++ b/MapboxDirections/MBDirectionsResponse.swift
@@ -134,10 +134,12 @@ public class MBRouteStep {
         case Continue = "continue"
         case PassNameChange = "new name"
         case Merge = "merge"
-        case TakeRamp = "ramp"
+        case TakeOnRamp = "on ramp"
+        case TakeOffRamp = "off ramp"
         case ReachFork = "fork"
         case ReachEnd = "end of road"
         case TakeRoundabout = "roundabout"
+        case TurnAtRoundabout = "roundabout turn"
         case HeedWarning = "notification"
         case Arrive = "arrive"
         


### PR DESCRIPTION
Replaced `TakeRamp` with `TakeOnRamp` and `TakeOffRamp`. Added `TurnAtRoundabout`. These types are already being returned by Directions API v5.

/cc @bsudekum