### PR TITLE
Add map to example application; fix example code

### DIFF
--- a/Directions Example/ViewController.swift
+++ b/Directions Example/ViewController.swift
@@ -1,28 +1,28 @@
 import UIKit
 import CoreLocation
 import MapboxDirections
+import Mapbox
 
 // A Mapbox access token is required to use the Directions API.
 // https://www.mapbox.com/help/create-api-access-token/
 let MapboxAccessToken = "<# your Mapbox access token #>"
 
 class ViewController: UIViewController {
+    @IBOutlet var mapView: MGLMapView!
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        
+        assert(MapboxAccessToken != "<# your Mapbox access token #>", "You must set `MapboxAccessToken` to your Mapbox access token.")
+        MGLAccountManager.setAccessToken(MapboxAccessToken)
+        
+        mapView = MGLMapView(frame: view.bounds)
+        mapView.autoresizingMask = [.FlexibleWidth, .FlexibleHeight]
+        view.addSubview(mapView)
+    }
+    
     override func viewDidAppear(animated: Bool) {
         super.viewDidAppear(animated)
-
-        assert(MapboxAccessToken != "<# your Mapbox access token #>", "You must set `MapboxAccessToken` to your Mapbox access token.")
-
-        view.addSubview({ [unowned self] in
-            let label = UILabel(frame: CGRect(x: (self.view.bounds.size.width - 200) / 2,
-                y: (self.view.bounds.size.height - 40) / 2,
-                width: 200,
-                height: 40))
-            label.autoresizingMask = [ .FlexibleLeftMargin, .FlexibleRightMargin, .FlexibleTopMargin, .FlexibleBottomMargin ]
-            label.textColor = UIColor.whiteColor()
-            label.textAlignment = .Center
-            label.text = "Check the console"
-            return label
-            }())
 
         let options = RouteOptions(waypoints: [
             Waypoint(coordinate: CLLocationCoordinate2D(latitude: 38.9131752, longitude: -77.0324047), name: "Mapbox"),
@@ -54,6 +54,16 @@ class ViewController: UIViewController {
                         let formattedDistance = distanceFormatter.stringFromMeters(step.distance)
                         print("— \(formattedDistance) —")
                     }
+                }
+                
+                if route.coordinateCount > 0 {
+                    // Convert the route’s coordinates into a polyline.
+                    var routeCoordinates = route.coordinates!
+                    let routeLine = MGLPolyline(coordinates: &routeCoordinates, count: route.coordinateCount)
+                    
+                    // Add the polyline to the map and fit the viewport to the polyline.
+                    self.mapView.addAnnotation(routeLine)
+                    self.mapView.setVisibleCoordinates(&routeCoordinates, count: route.coordinateCount, edgePadding:                 UIEdgeInsetsZero, animated: true)
                 }
             }
         }

--- a/Podfile
+++ b/Podfile
@@ -47,4 +47,5 @@ end
 target 'Example (Swift)' do
   platform :ios, '8.0'
   shared_pods
+  pod 'Mapbox-iOS-SDK', '~> 3.2'
 end

--- a/README.md
+++ b/README.md
@@ -105,8 +105,8 @@ let task = directions.calculateDirections(options: options) { (waypoints, routes
 // main.m
 
 NSArray<MBWaypoint *> *waypoints = @[
-    [[MBWaypoint alloc] initWithCoordinate:CLLocationCoordinate2DMake(38.9131752, -77.0324047), @"Mapbox"],
-    [[MBWaypoint alloc] initWithCoordinate:CLLocationCoordinate2DMake(38.8977, -77.0365), @"White House"],
+    [[MBWaypoint alloc] initWithCoordinate:CLLocationCoordinate2DMake(38.9131752, -77.0324047) name:@"Mapbox"],
+    [[MBWaypoint alloc] initWithCoordinate:CLLocationCoordinate2DMake(38.8977, -77.0365) name:@"White House"],
 ];
 MBRouteOptions *options = [[MBRouteOptions alloc] initWithWaypoints:waypoints
                                                   profileIdentifier:MBDirectionsProfileIdentifierAutomobile];
@@ -160,7 +160,7 @@ if route.coordinateCount > 0 {
     
     // Add the polyline to the map and fit the viewport to the polyline.
     mapView.addAnnotation(routeLine)
-    mapView.setVisibleCoordinates(routeCoordinates, count: route.coordinateCount, edgePadding: UIEdgeInsetsZero, animated: true)
+    mapView.setVisibleCoordinates(&routeCoordinates, count: route.coordinateCount, edgePadding: UIEdgeInsetsZero, animated: true)
 }
 ```
 


### PR DESCRIPTION
This PR fixes typos in example code in the README. It also adds a map to the example application that shows the route line, replacing the label that said simply to look at the console. (The console output is still there.)

Fixes #56.

/cc @friedbunny @tmcw