### PR TITLE
Added AppleScript examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@
 
 MapboxDirections.swift makes it easy to connect your iOS, macOS, tvOS, or watchOS application to the [Mapbox Directions API](https://www.mapbox.com/directions/). Quickly get driving, cycling, or walking directions, whether the trip is nonstop or it has multiple stopping points, all using a simple interface reminiscent of MapKit’s `MKDirections` API. The Mapbox Directions API is powered by the [OSRM](http://project-osrm.org/) routing engine and open data from the [OpenStreetMap](https://www.openstreetmap.org/) project.
 
+Despite its name, MapboxDirections.swift works in Objective-C and Cocoa-AppleScript code in addition to Swift.
+
 MapboxDirections.swift pairs well with [MapboxGeocoder.swift](https://github.com/mapbox/MapboxGeocoder.swift), [MapboxStatic.swift](https://github.com/mapbox/MapboxStatic.swift), and the [Mapbox iOS SDK](https://www.mapbox.com/ios-sdk/) or [macOS SDK](https://github.com/mapbox/mapbox-gl-native/tree/master/platform/macos).
 
 ## Getting started
@@ -34,7 +36,7 @@ You’ll need a [Mapbox access token](https://www.mapbox.com/developers/api/#acc
 
 ### Basics
 
-The main directions class is Directions in Swift or MBDirections in Objective-C. Create a directions object using your access token:
+The main directions class is Directions (in Swift) or MBDirections (in Objective-C or AppleScript). Create a directions object using your access token:
 
 ```swift
 // main.swift
@@ -50,6 +52,12 @@ let directions = Directions(accessToken: "<#your access token#>")
 MBDirections *directions = [[MBDirections alloc] initWithAccessToken:@"<#your access token#>"];
 ```
 
+```applescript
+// AppDelegate.applescript
+set theDirections to alloc of MBDirections of the current application
+tell theDirections to initWithAccessToken:"<#your access token#>"
+```
+
 Alternatively, you can place your access token in the `MGLMapboxAccessToken` key of your application’s Info.plist file, then use the shared directions object:
 
 ```swift
@@ -60,6 +68,11 @@ let directions = Directions.sharedDirections
 ```objc
 // main.m
 MBDirections *directions = [MBDirections sharedDirections];
+```
+
+```applescript
+// AppDelegate.applescript
+set theDirections to sharedDirections of MBDirections of the current application
 ```
 
 With the directions object in hand, construct a RouteOptions or MBRouteOptions object and pass it into the `Directions.calculateDirections(options:completionHandler:)` method.
@@ -105,8 +118,8 @@ let task = directions.calculateDirections(options: options) { (waypoints, routes
 // main.m
 
 NSArray<MBWaypoint *> *waypoints = @[
-    [[MBWaypoint alloc] initWithCoordinate:CLLocationCoordinate2DMake(38.9131752, -77.0324047) name:@"Mapbox"],
-    [[MBWaypoint alloc] initWithCoordinate:CLLocationCoordinate2DMake(38.8977, -77.0365) name:@"White House"],
+    [[MBWaypoint alloc] initWithCoordinate:CLLocationCoordinate2DMake(38.9131752, -77.0324047) coordinateAccuracy:-1 name:@"Mapbox"],
+    [[MBWaypoint alloc] initWithCoordinate:CLLocationCoordinate2DMake(38.8977, -77.0365) coordinateAccuracy:-1 name:@"White House"],
 ];
 MBRouteOptions *options = [[MBRouteOptions alloc] initWithWaypoints:waypoints
                                                   profileIdentifier:MBDirectionsProfileIdentifierAutomobile];
@@ -144,11 +157,47 @@ NSURLSessionDataTask *task = [directions calculateDirectionsWithOptions:options
 }];
 ```
 
+```
+// AppDelegate.applescript
+
+set mapbox to alloc of MBWaypoint of the current application
+tell mapbox to initWithCoordinate:{38.9131752, -77.0324047} coordinateAccuracy:-1 |name|:"Mapbox"
+set theWhiteHouse to alloc of MBWaypoint of the current application
+tell theWhiteHouse to initWithCoordinate:{38.8977, -77.0365} coordinateAccuracy:-1 |name|:"White House"
+set theWaypoints to {mapbox, theWhiteHouse}
+
+set theOptions to alloc of MBRouteOptions of the current application
+tell theOptions to initWithWaypoints:theWaypoints profileIdentifier:"mapbox/driving"
+set theOptions's includesSteps to true
+
+set theURL to theDirections's URLForCalculatingDirectionsWithOptions:theOptions
+set theData to the current application's NSData's dataWithContentsOfURL:theURL
+set theJSON to the current application's NSJSONSerialization's JSONObjectWithData:theData options:0 |error|:(missing value)
+
+set theRoute to alloc of MBRoute of the current application
+tell theRoute to initWithJson:(the first item of theJSON's routes) waypoints:theWaypoints profileIdentifier:"mapbox/driving"
+set theLeg to the first item of theRoute's legs
+
+log "Route via " & theLeg's |name| & ":"
+
+set theDistanceFormatter to alloc of NSLengthFormatter of the current application
+tell theDistanceFormatter to init()
+set theDistance to theDistanceFormatter's stringFromMeters:(theLeg's distance)
+
+log "Distance: " & theDistance
+
+repeat with theStep in theLeg's steps
+    log theStep's instructions
+    set theDistance to theDistanceFormatter's stringFromMeters:(theStep's distance)
+    log "— " & theDistance & " —"
+end repeat
+```
+
 This library uses version 5 of the Mapbox Directions API by default. To use version 4 instead, replace RouteOptions with RouteOptionsV4 (or MBRouteOptions with MBRouteOptionsV4).
 
 ### Drawing the route on a map
 
-With the [Mapbox iOS SDK](https://www.mapbox.com/ios-sdk/) or [macOS SDK](https://github.com/mapbox/mapbox-gl-native/tree/master/platform/macos), you can easily draw the route on a map:
+With the [Mapbox iOS SDK](https://www.mapbox.com/ios-sdk/) or [macOS SDK](https://github.com/mapbox/mapbox-gl-native/tree/master/platform/macos), you can easily draw the route on a map in Swift or Objective-C:
 
 ```swift
 // main.swift

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ MBDirections *directions = [[MBDirections alloc] initWithAccessToken:@"<#your ac
 ```
 
 ```applescript
-// AppDelegate.applescript
+-- AppDelegate.applescript
 set theDirections to alloc of MBDirections of the current application
 tell theDirections to initWithAccessToken:"<#your access token#>"
 ```
@@ -71,7 +71,7 @@ MBDirections *directions = [MBDirections sharedDirections];
 ```
 
 ```applescript
-// AppDelegate.applescript
+-- AppDelegate.applescript
 set theDirections to sharedDirections of MBDirections of the current application
 ```
 
@@ -158,7 +158,7 @@ NSURLSessionDataTask *task = [directions calculateDirectionsWithOptions:options
 ```
 
 ```
-// AppDelegate.applescript
+-- AppDelegate.applescript
 
 set mapbox to alloc of MBWaypoint of the current application
 tell mapbox to initWithCoordinate:{38.9131752, -77.0324047} coordinateAccuracy:-1 |name|:"Mapbox"


### PR DESCRIPTION
Why not?

Actually, the main reason for this change is to fix yet another error in the Objective-C examples, caused by an inability to bridge optional parameters from Swift to Objective-C.

/cc @friedbunny