### PR TITLE
Migrate to Swift 2.3

### DIFF
--- a/MapboxDirections.xcodeproj/project.pbxproj
+++ b/MapboxDirections.xcodeproj/project.pbxproj
@@ -14,6 +14,17 @@
 		9186F83B6B5B9BA4218C6949 /* Pods_MapboxDirectionsTV.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 30A35E89A250687A8A4AB203 /* Pods_MapboxDirectionsTV.framework */; };
 		A6270373DE8FBAB9E187546B /* Pods_MapboxDirections.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 83C0BE684BDAC6904D8772FE /* Pods_MapboxDirections.framework */; };
 		B225EEC832101659D42306C0 /* Pods_MapboxDirectionsMac.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D5A2AC67B9674D3F14B1FD6E /* Pods_MapboxDirectionsMac.framework */; };
+		BCC275D33FD809E4CA0C29E3 /* Pods_WatchExample.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3125F8C3D3D120492CC28912 /* Pods_WatchExample.framework */; };
+		DA15B1A01D5D501500C8042B /* Interface.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = DA15B19E1D5D501500C8042B /* Interface.storyboard */; };
+		DA15B1A21D5D501500C8042B /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = DA15B1A11D5D501500C8042B /* Assets.xcassets */; };
+		DA15B1A91D5D501500C8042B /* WatchExample Extension.appex in Embed App Extensions */ = {isa = PBXBuildFile; fileRef = DA15B1A81D5D501500C8042B /* WatchExample Extension.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
+		DA15B1B01D5D501500C8042B /* InterfaceController.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA15B1AF1D5D501500C8042B /* InterfaceController.swift */; };
+		DA15B1B21D5D501500C8042B /* ExtensionDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA15B1B11D5D501500C8042B /* ExtensionDelegate.swift */; };
+		DA15B1B41D5D501500C8042B /* NotificationController.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA15B1B31D5D501500C8042B /* NotificationController.swift */; };
+		DA15B1B61D5D501500C8042B /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = DA15B1B51D5D501500C8042B /* Assets.xcassets */; };
+		DA15B1BA1D5D501500C8042B /* WatchExample.app in Embed Watch Content */ = {isa = PBXBuildFile; fileRef = DA15B19C1D5D501500C8042B /* WatchExample.app */; };
+		DA15B1C31D5D502900C8042B /* MapboxDirections.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DA1A10FB1D010361009F82FA /* MapboxDirections.framework */; };
+		DA15B1C41D5D502900C8042B /* MapboxDirections.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = DA1A10FB1D010361009F82FA /* MapboxDirections.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		DA1A10C61D00F969009F82FA /* MapboxDirections.h in Headers */ = {isa = PBXBuildFile; fileRef = DA6C9D8A1CAE442B00094FBC /* MapboxDirections.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		DA1A10C71D00F969009F82FA /* MBDirections.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD6254731AE70CB700017857 /* MBDirections.swift */; };
 		DA1A10C81D00F969009F82FA /* MBRoute.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAC05F171CFC075300FA0071 /* MBRoute.swift */; };
@@ -74,6 +85,27 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
+		DA15B1AA1D5D501500C8042B /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = DD6254461AE70C1700017857 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = DA15B1A71D5D501500C8042B;
+			remoteInfo = "WatchExample Extension";
+		};
+		DA15B1B81D5D501500C8042B /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = DD6254461AE70C1700017857 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = DA15B19B1D5D501500C8042B;
+			remoteInfo = WatchExample;
+		};
+		DA15B1C51D5D502900C8042B /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = DD6254461AE70C1700017857 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = DA1A10FA1D010361009F82FA;
+			remoteInfo = MapboxDirectionsWatch;
+		};
 		DA1A10BA1D00F8FF009F82FA /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = DD6254461AE70C1700017857 /* Project object */;
@@ -105,6 +137,39 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXCopyFilesBuildPhase section */
+		DA15B1C01D5D501500C8042B /* Embed App Extensions */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 13;
+			files = (
+				DA15B1A91D5D501500C8042B /* WatchExample Extension.appex in Embed App Extensions */,
+			);
+			name = "Embed App Extensions";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		DA15B1C21D5D501500C8042B /* Embed Watch Content */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "$(CONTENTS_FOLDER_PATH)/Watch";
+			dstSubfolderSpec = 16;
+			files = (
+				DA15B1BA1D5D501500C8042B /* WatchExample.app in Embed Watch Content */,
+			);
+			name = "Embed Watch Content";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		DA15B1C81D5D502A00C8042B /* Embed Frameworks */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 10;
+			files = (
+				DA15B1C41D5D502900C8042B /* MapboxDirections.framework in Embed Frameworks */,
+			);
+			name = "Embed Frameworks";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		DA1A11151D011089009F82FA /* Embed Frameworks */ = {
 			isa = PBXCopyFilesBuildPhase;
 			buildActionMask = 2147483647;
@@ -119,24 +184,40 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
-		0C59B42BC819E63045BBE9A8 /* Pods-MapboxDirectionsWatch.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-MapboxDirectionsWatch.release.xcconfig"; path = "Pods/Target Support Files/Pods-MapboxDirectionsWatch/Pods-MapboxDirectionsWatch.release.xcconfig"; sourceTree = "<group>"; };
-		0FD4719FAB56964485A4E090 /* Pods-MapboxDirectionsTV.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-MapboxDirectionsTV.debug.xcconfig"; path = "Pods/Target Support Files/Pods-MapboxDirectionsTV/Pods-MapboxDirectionsTV.debug.xcconfig"; sourceTree = "<group>"; };
+		05045275F3647340E9698D26 /* Pods-WatchExample.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-WatchExample.release.xcconfig"; path = "Pods/Target Support Files/Pods-WatchExample/Pods-WatchExample.release.xcconfig"; sourceTree = "<group>"; };
+		0E54F34CE80B8FAA8A8237AF /* Pods-MapboxDirectionsMac.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-MapboxDirectionsMac.release.xcconfig"; path = "Pods/Target Support Files/Pods-MapboxDirectionsMac/Pods-MapboxDirectionsMac.release.xcconfig"; sourceTree = "<group>"; };
 		111718728E71A72F760BFBCE /* Pods_MapboxDirectionsTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_MapboxDirectionsTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		26F4C3A5D5ABF163E53BBAAE /* Pods-MapboxDirectionsMac.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-MapboxDirectionsMac.release.xcconfig"; path = "Pods/Target Support Files/Pods-MapboxDirectionsMac/Pods-MapboxDirectionsMac.release.xcconfig"; sourceTree = "<group>"; };
+		14A212D3093A6B2F16C5906B /* Pods-MapboxDirectionsWatch.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-MapboxDirectionsWatch.release.xcconfig"; path = "Pods/Target Support Files/Pods-MapboxDirectionsWatch/Pods-MapboxDirectionsWatch.release.xcconfig"; sourceTree = "<group>"; };
+		280512B2AFE7777BE47B598C /* Pods-Example (Swift).debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Example (Swift).debug.xcconfig"; path = "Pods/Target Support Files/Pods-Example (Swift)/Pods-Example (Swift).debug.xcconfig"; sourceTree = "<group>"; };
 		2AF00AB3EFDCBBCCD611EFB8 /* Pods_Example__Swift_.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Example__Swift_.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		2E1E30C7261B1CC9E446EF14 /* Pods-MapboxDirectionsWatch.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-MapboxDirectionsWatch.debug.xcconfig"; path = "Pods/Target Support Files/Pods-MapboxDirectionsWatch/Pods-MapboxDirectionsWatch.debug.xcconfig"; sourceTree = "<group>"; };
 		30A35E89A250687A8A4AB203 /* Pods_MapboxDirectionsTV.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_MapboxDirectionsTV.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		3A3200DC60F96A1525D1916C /* Pods-MapboxDirectionsMac.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-MapboxDirectionsMac.debug.xcconfig"; path = "Pods/Target Support Files/Pods-MapboxDirectionsMac/Pods-MapboxDirectionsMac.debug.xcconfig"; sourceTree = "<group>"; };
-		41AC8B888A90DD5CDAE8E86F /* Pods-Example (Swift).debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Example (Swift).debug.xcconfig"; path = "Pods/Target Support Files/Pods-Example (Swift)/Pods-Example (Swift).debug.xcconfig"; sourceTree = "<group>"; };
-		52BAF0302AAF3051E5A31D2F /* Pods-MapboxDirections.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-MapboxDirections.release.xcconfig"; path = "Pods/Target Support Files/Pods-MapboxDirections/Pods-MapboxDirections.release.xcconfig"; sourceTree = "<group>"; };
-		6ED1E050D32520EDBDD3D372 /* Pods-MapboxDirectionsTVTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-MapboxDirectionsTVTests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-MapboxDirectionsTVTests/Pods-MapboxDirectionsTVTests.debug.xcconfig"; sourceTree = "<group>"; };
-		7F5C6C4953282E544499886B /* Pods-MapboxDirections.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-MapboxDirections.debug.xcconfig"; path = "Pods/Target Support Files/Pods-MapboxDirections/Pods-MapboxDirections.debug.xcconfig"; sourceTree = "<group>"; };
+		3125F8C3D3D120492CC28912 /* Pods_WatchExample.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_WatchExample.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		3CBDF466DA79A0300E88AA8C /* Pods-MapboxDirections.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-MapboxDirections.debug.xcconfig"; path = "Pods/Target Support Files/Pods-MapboxDirections/Pods-MapboxDirections.debug.xcconfig"; sourceTree = "<group>"; };
+		45D272931D93A2185C1F3140 /* Pods-MapboxDirectionsTV.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-MapboxDirectionsTV.release.xcconfig"; path = "Pods/Target Support Files/Pods-MapboxDirectionsTV/Pods-MapboxDirectionsTV.release.xcconfig"; sourceTree = "<group>"; };
+		46B778CDD353A9BEFD44A098 /* Pods-MapboxDirectionsTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-MapboxDirectionsTests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-MapboxDirectionsTests/Pods-MapboxDirectionsTests.debug.xcconfig"; sourceTree = "<group>"; };
+		5ABC95CC4D6BF3BCA6667F5C /* Pods-Example (Swift).release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Example (Swift).release.xcconfig"; path = "Pods/Target Support Files/Pods-Example (Swift)/Pods-Example (Swift).release.xcconfig"; sourceTree = "<group>"; };
+		7AB05E29E43D55326F7FA67B /* Pods-WatchExample.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-WatchExample.debug.xcconfig"; path = "Pods/Target Support Files/Pods-WatchExample/Pods-WatchExample.debug.xcconfig"; sourceTree = "<group>"; };
+		7E3FF4F9120D6C9E60708335 /* Pods-MapboxDirectionsMacTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-MapboxDirectionsMacTests.release.xcconfig"; path = "Pods/Target Support Files/Pods-MapboxDirectionsMacTests/Pods-MapboxDirectionsMacTests.release.xcconfig"; sourceTree = "<group>"; };
 		83C0BE684BDAC6904D8772FE /* Pods_MapboxDirections.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_MapboxDirections.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		844B8A6B18AB25E1ED023074 /* Pods-MapboxDirectionsTV.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-MapboxDirectionsTV.release.xcconfig"; path = "Pods/Target Support Files/Pods-MapboxDirectionsTV/Pods-MapboxDirectionsTV.release.xcconfig"; sourceTree = "<group>"; };
-		8742F3B5D746590C8C2FA4CA /* Pods-MapboxDirectionsTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-MapboxDirectionsTests.release.xcconfig"; path = "Pods/Target Support Files/Pods-MapboxDirectionsTests/Pods-MapboxDirectionsTests.release.xcconfig"; sourceTree = "<group>"; };
-		982B076C0E044A2F180CE50D /* Pods-MapboxDirectionsTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-MapboxDirectionsTests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-MapboxDirectionsTests/Pods-MapboxDirectionsTests.debug.xcconfig"; sourceTree = "<group>"; };
 		A6C14CAB4265B5BBE0668F98 /* Pods_MapboxDirectionsMacTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_MapboxDirectionsMacTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		B138892B1F6A8960575D68D6 /* Pods-MapboxDirectionsMac.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-MapboxDirectionsMac.debug.xcconfig"; path = "Pods/Target Support Files/Pods-MapboxDirectionsMac/Pods-MapboxDirectionsMac.debug.xcconfig"; sourceTree = "<group>"; };
+		B215B2487667504F84228843 /* Pods-MapboxDirectionsTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-MapboxDirectionsTests.release.xcconfig"; path = "Pods/Target Support Files/Pods-MapboxDirectionsTests/Pods-MapboxDirectionsTests.release.xcconfig"; sourceTree = "<group>"; };
+		BEAF6404FB359F49700E9114 /* Pods-MapboxDirectionsTVTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-MapboxDirectionsTVTests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-MapboxDirectionsTVTests/Pods-MapboxDirectionsTVTests.debug.xcconfig"; sourceTree = "<group>"; };
+		C5216CD064790304C0D12E08 /* Pods-MapboxDirectionsMacTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-MapboxDirectionsMacTests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-MapboxDirectionsMacTests/Pods-MapboxDirectionsMacTests.debug.xcconfig"; sourceTree = "<group>"; };
+		D39D92434CEA7E755F68A0DD /* Pods-MapboxDirectionsTVTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-MapboxDirectionsTVTests.release.xcconfig"; path = "Pods/Target Support Files/Pods-MapboxDirectionsTVTests/Pods-MapboxDirectionsTVTests.release.xcconfig"; sourceTree = "<group>"; };
 		D5A2AC67B9674D3F14B1FD6E /* Pods_MapboxDirectionsMac.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_MapboxDirectionsMac.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		D6B9D6C6A2118801E17F73AC /* Pods-MapboxDirectionsMacTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-MapboxDirectionsMacTests.release.xcconfig"; path = "Pods/Target Support Files/Pods-MapboxDirectionsMacTests/Pods-MapboxDirectionsMacTests.release.xcconfig"; sourceTree = "<group>"; };
+		DA15B19C1D5D501500C8042B /* WatchExample.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = WatchExample.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		DA15B19F1D5D501500C8042B /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Interface.storyboard; sourceTree = "<group>"; };
+		DA15B1A11D5D501500C8042B /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		DA15B1A31D5D501500C8042B /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		DA15B1A81D5D501500C8042B /* WatchExample Extension.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = "WatchExample Extension.appex"; sourceTree = BUILT_PRODUCTS_DIR; };
+		DA15B1AE1D5D501500C8042B /* PushNotificationPayload.apns */ = {isa = PBXFileReference; lastKnownFileType = text; path = PushNotificationPayload.apns; sourceTree = "<group>"; };
+		DA15B1AF1D5D501500C8042B /* InterfaceController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InterfaceController.swift; sourceTree = "<group>"; };
+		DA15B1B11D5D501500C8042B /* ExtensionDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExtensionDelegate.swift; sourceTree = "<group>"; };
+		DA15B1B31D5D501500C8042B /* NotificationController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationController.swift; sourceTree = "<group>"; };
+		DA15B1B51D5D501500C8042B /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		DA15B1B71D5D501500C8042B /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		DA1A10AF1D00F8FF009F82FA /* MapboxDirections.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = MapboxDirections.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		DA1A10B81D00F8FF009F82FA /* MapboxDirectionsTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = MapboxDirectionsTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		DA1A10D51D0101ED009F82FA /* MapboxDirections.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = MapboxDirections.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -167,11 +248,9 @@
 		DD6254551AE70C1700017857 /* ViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewController.swift; sourceTree = "<group>"; };
 		DD6254731AE70CB700017857 /* MBDirections.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MBDirections.swift; sourceTree = "<group>"; };
 		DE88D8ACDE1F58C6F7CFF289 /* Pods_MapboxDirectionsWatch.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_MapboxDirectionsWatch.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		E32FD2E0FD00A2CAF23B8BBD /* Pods-MapboxDirectionsTV.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-MapboxDirectionsTV.debug.xcconfig"; path = "Pods/Target Support Files/Pods-MapboxDirectionsTV/Pods-MapboxDirectionsTV.debug.xcconfig"; sourceTree = "<group>"; };
 		EBA232D519F6F671B2EDFCAF /* Pods_MapboxDirectionsTVTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_MapboxDirectionsTVTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		EC7AF27DBE65271A314C18B6 /* Pods-MapboxDirectionsWatch.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-MapboxDirectionsWatch.debug.xcconfig"; path = "Pods/Target Support Files/Pods-MapboxDirectionsWatch/Pods-MapboxDirectionsWatch.debug.xcconfig"; sourceTree = "<group>"; };
-		EDF0BB33D58A513BC08576AA /* Pods-Example (Swift).release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Example (Swift).release.xcconfig"; path = "Pods/Target Support Files/Pods-Example (Swift)/Pods-Example (Swift).release.xcconfig"; sourceTree = "<group>"; };
-		F59A464651694E5ECFA36D60 /* Pods-MapboxDirectionsTVTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-MapboxDirectionsTVTests.release.xcconfig"; path = "Pods/Target Support Files/Pods-MapboxDirectionsTVTests/Pods-MapboxDirectionsTVTests.release.xcconfig"; sourceTree = "<group>"; };
-		FB735824DBD14927E8AC411B /* Pods-MapboxDirectionsMacTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-MapboxDirectionsMacTests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-MapboxDirectionsMacTests/Pods-MapboxDirectionsMacTests.debug.xcconfig"; sourceTree = "<group>"; };
+		F91F172DFB1E0945243533D7 /* Pods-MapboxDirections.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-MapboxDirections.release.xcconfig"; path = "Pods/Target Support Files/Pods-MapboxDirections/Pods-MapboxDirections.release.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -223,6 +302,22 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		DA15B1A51D5D501500C8042B /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		DA15B1C71D5D502900C8042B /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				DA15B1C31D5D502900C8042B /* MapboxDirections.framework in Frameworks */,
+				BCC275D33FD809E4CA0C29E3 /* Pods_WatchExample.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		DD62544B1AE70C1700017857 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
@@ -243,29 +338,6 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
-		3502E475556C18DBED04DEAC /* Pods */ = {
-			isa = PBXGroup;
-			children = (
-				7F5C6C4953282E544499886B /* Pods-MapboxDirections.debug.xcconfig */,
-				52BAF0302AAF3051E5A31D2F /* Pods-MapboxDirections.release.xcconfig */,
-				982B076C0E044A2F180CE50D /* Pods-MapboxDirectionsTests.debug.xcconfig */,
-				8742F3B5D746590C8C2FA4CA /* Pods-MapboxDirectionsTests.release.xcconfig */,
-				3A3200DC60F96A1525D1916C /* Pods-MapboxDirectionsMac.debug.xcconfig */,
-				26F4C3A5D5ABF163E53BBAAE /* Pods-MapboxDirectionsMac.release.xcconfig */,
-				FB735824DBD14927E8AC411B /* Pods-MapboxDirectionsMacTests.debug.xcconfig */,
-				D6B9D6C6A2118801E17F73AC /* Pods-MapboxDirectionsMacTests.release.xcconfig */,
-				0FD4719FAB56964485A4E090 /* Pods-MapboxDirectionsTV.debug.xcconfig */,
-				844B8A6B18AB25E1ED023074 /* Pods-MapboxDirectionsTV.release.xcconfig */,
-				6ED1E050D32520EDBDD3D372 /* Pods-MapboxDirectionsTVTests.debug.xcconfig */,
-				F59A464651694E5ECFA36D60 /* Pods-MapboxDirectionsTVTests.release.xcconfig */,
-				EC7AF27DBE65271A314C18B6 /* Pods-MapboxDirectionsWatch.debug.xcconfig */,
-				0C59B42BC819E63045BBE9A8 /* Pods-MapboxDirectionsWatch.release.xcconfig */,
-				41AC8B888A90DD5CDAE8E86F /* Pods-Example (Swift).debug.xcconfig */,
-				EDF0BB33D58A513BC08576AA /* Pods-Example (Swift).release.xcconfig */,
-			);
-			name = Pods;
-			sourceTree = "<group>";
-		};
 		4025371970E36C6D8BF67116 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
@@ -278,8 +350,40 @@
 				EBA232D519F6F671B2EDFCAF /* Pods_MapboxDirectionsTVTests.framework */,
 				DE88D8ACDE1F58C6F7CFF289 /* Pods_MapboxDirectionsWatch.framework */,
 				2AF00AB3EFDCBBCCD611EFB8 /* Pods_Example__Swift_.framework */,
+				3125F8C3D3D120492CC28912 /* Pods_WatchExample.framework */,
 			);
 			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		DA15B19D1D5D501500C8042B /* WatchExample */ = {
+			isa = PBXGroup;
+			children = (
+				DA15B19E1D5D501500C8042B /* Interface.storyboard */,
+				DA15B1A11D5D501500C8042B /* Assets.xcassets */,
+				DA15B1A31D5D501500C8042B /* Info.plist */,
+			);
+			path = WatchExample;
+			sourceTree = "<group>";
+		};
+		DA15B1AC1D5D501500C8042B /* WatchExample Extension */ = {
+			isa = PBXGroup;
+			children = (
+				DA15B1AF1D5D501500C8042B /* InterfaceController.swift */,
+				DA15B1B11D5D501500C8042B /* ExtensionDelegate.swift */,
+				DA15B1B31D5D501500C8042B /* NotificationController.swift */,
+				DA15B1B51D5D501500C8042B /* Assets.xcassets */,
+				DA15B1B71D5D501500C8042B /* Info.plist */,
+				DA15B1AD1D5D501500C8042B /* Supporting Files */,
+			);
+			path = "WatchExample Extension";
+			sourceTree = "<group>";
+		};
+		DA15B1AD1D5D501500C8042B /* Supporting Files */ = {
+			isa = PBXGroup;
+			children = (
+				DA15B1AE1D5D501500C8042B /* PushNotificationPayload.apns */,
+			);
+			name = "Supporting Files";
 			sourceTree = "<group>";
 		};
 		DA1A10541D001C4E009F82FA /* Swift */ = {
@@ -354,9 +458,11 @@
 				DD6254501AE70C1700017857 /* Directions Example */,
 				DA6C9D891CAE442B00094FBC /* MapboxDirections */,
 				DA6C9D971CAE442B00094FBC /* MapboxDirectionsTests */,
+				DA15B19D1D5D501500C8042B /* WatchExample */,
+				DA15B1AC1D5D501500C8042B /* WatchExample Extension */,
 				DD62544F1AE70C1700017857 /* Products */,
 				4025371970E36C6D8BF67116 /* Frameworks */,
-				3502E475556C18DBED04DEAC /* Pods */,
+				DE76C0739C1B67D5BF639537 /* Pods */,
 			);
 			sourceTree = "<group>";
 		};
@@ -371,6 +477,8 @@
 				DA1A10D51D0101ED009F82FA /* MapboxDirections.framework */,
 				DA1A10DE1D0101ED009F82FA /* MapboxDirectionsTests.xctest */,
 				DA1A10FB1D010361009F82FA /* MapboxDirections.framework */,
+				DA15B19C1D5D501500C8042B /* WatchExample.app */,
+				DA15B1A81D5D501500C8042B /* WatchExample Extension.appex */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -390,6 +498,31 @@
 				DD6254521AE70C1700017857 /* Info.plist */,
 			);
 			name = "Supporting Files";
+			sourceTree = "<group>";
+		};
+		DE76C0739C1B67D5BF639537 /* Pods */ = {
+			isa = PBXGroup;
+			children = (
+				280512B2AFE7777BE47B598C /* Pods-Example (Swift).debug.xcconfig */,
+				5ABC95CC4D6BF3BCA6667F5C /* Pods-Example (Swift).release.xcconfig */,
+				3CBDF466DA79A0300E88AA8C /* Pods-MapboxDirections.debug.xcconfig */,
+				F91F172DFB1E0945243533D7 /* Pods-MapboxDirections.release.xcconfig */,
+				B138892B1F6A8960575D68D6 /* Pods-MapboxDirectionsMac.debug.xcconfig */,
+				0E54F34CE80B8FAA8A8237AF /* Pods-MapboxDirectionsMac.release.xcconfig */,
+				C5216CD064790304C0D12E08 /* Pods-MapboxDirectionsMacTests.debug.xcconfig */,
+				7E3FF4F9120D6C9E60708335 /* Pods-MapboxDirectionsMacTests.release.xcconfig */,
+				E32FD2E0FD00A2CAF23B8BBD /* Pods-MapboxDirectionsTV.debug.xcconfig */,
+				45D272931D93A2185C1F3140 /* Pods-MapboxDirectionsTV.release.xcconfig */,
+				BEAF6404FB359F49700E9114 /* Pods-MapboxDirectionsTVTests.debug.xcconfig */,
+				D39D92434CEA7E755F68A0DD /* Pods-MapboxDirectionsTVTests.release.xcconfig */,
+				46B778CDD353A9BEFD44A098 /* Pods-MapboxDirectionsTests.debug.xcconfig */,
+				B215B2487667504F84228843 /* Pods-MapboxDirectionsTests.release.xcconfig */,
+				2E1E30C7261B1CC9E446EF14 /* Pods-MapboxDirectionsWatch.debug.xcconfig */,
+				14A212D3093A6B2F16C5906B /* Pods-MapboxDirectionsWatch.release.xcconfig */,
+				7AB05E29E43D55326F7FA67B /* Pods-WatchExample.debug.xcconfig */,
+				05045275F3647340E9698D26 /* Pods-WatchExample.release.xcconfig */,
+			);
+			name = Pods;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -430,16 +563,55 @@
 /* End PBXHeadersBuildPhase section */
 
 /* Begin PBXNativeTarget section */
+		DA15B19B1D5D501500C8042B /* WatchExample */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = DA15B1C11D5D501500C8042B /* Build configuration list for PBXNativeTarget "WatchExample" */;
+			buildPhases = (
+				23C21BECDCC715D9124A5E09 /* [CP] Check Pods Manifest.lock */,
+				DA15B19A1D5D501500C8042B /* Resources */,
+				DA15B1C01D5D501500C8042B /* Embed App Extensions */,
+				DA15B1C71D5D502900C8042B /* Frameworks */,
+				DA15B1C81D5D502A00C8042B /* Embed Frameworks */,
+				6BC16E4F89B70B99A5E06E71 /* [CP] Copy Pods Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				DA15B1AB1D5D501500C8042B /* PBXTargetDependency */,
+				DA15B1C61D5D502900C8042B /* PBXTargetDependency */,
+			);
+			name = WatchExample;
+			productName = WatchExample;
+			productReference = DA15B19C1D5D501500C8042B /* WatchExample.app */;
+			productType = "com.apple.product-type.application.watchapp2";
+		};
+		DA15B1A71D5D501500C8042B /* WatchExample Extension */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = DA15B1BF1D5D501500C8042B /* Build configuration list for PBXNativeTarget "WatchExample Extension" */;
+			buildPhases = (
+				DA15B1A41D5D501500C8042B /* Sources */,
+				DA15B1A51D5D501500C8042B /* Frameworks */,
+				DA15B1A61D5D501500C8042B /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "WatchExample Extension";
+			productName = "WatchExample Extension";
+			productReference = DA15B1A81D5D501500C8042B /* WatchExample Extension.appex */;
+			productType = "com.apple.product-type.watchkit2-extension";
+		};
 		DA1A10AE1D00F8FF009F82FA /* MapboxDirectionsMac */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = DA1A10C41D00F8FF009F82FA /* Build configuration list for PBXNativeTarget "MapboxDirectionsMac" */;
 			buildPhases = (
-				65B9BC290124777B27A8EE0C /* [CP] Check Pods Manifest.lock */,
+				07EB541A056F200DC7890508 /* [CP] Check Pods Manifest.lock */,
 				DA1A10AA1D00F8FF009F82FA /* Sources */,
 				DA1A10AC1D00F8FF009F82FA /* Headers */,
 				DA1A10AD1D00F8FF009F82FA /* Resources */,
-				A7AA2C0E4B916A0B8CE44754 /* [CP] Copy Pods Resources */,
 				653A4672B83CA07822A37632 /* Frameworks */,
+				2A512AB2F5C1E6C58DEF5E51 /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -454,12 +626,12 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = DA1A10C51D00F8FF009F82FA /* Build configuration list for PBXNativeTarget "MapboxDirectionsMacTests" */;
 			buildPhases = (
-				422B38CA821F5EA5A289825D /* [CP] Check Pods Manifest.lock */,
+				164BE52AA118E9B230A12CB4 /* [CP] Check Pods Manifest.lock */,
 				DA1A10B41D00F8FF009F82FA /* Sources */,
 				DA1A10B61D00F8FF009F82FA /* Resources */,
-				31D6B942299D49FEB7DF0BA7 /* [CP] Embed Pods Frameworks */,
-				62F2CAEB1090FB9B4C74443A /* [CP] Copy Pods Resources */,
 				39D04EFCE1A7300374AA5FBF /* Frameworks */,
+				CA9D333DD4D637ED30DA1B5D /* [CP] Embed Pods Frameworks */,
+				B146922AAE71DC82A56BBA60 /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -475,12 +647,12 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = DA1A10EA1D0101ED009F82FA /* Build configuration list for PBXNativeTarget "MapboxDirectionsTV" */;
 			buildPhases = (
-				645B8814CE6BF41CF300B389 /* [CP] Check Pods Manifest.lock */,
+				690FF18CD3B69F7D8CD139CC /* [CP] Check Pods Manifest.lock */,
 				DA1A10D01D0101ED009F82FA /* Sources */,
 				DA1A10D21D0101ED009F82FA /* Headers */,
 				DA1A10D31D0101ED009F82FA /* Resources */,
-				9969583F2E1AC2D68717395B /* [CP] Copy Pods Resources */,
 				84AE54CA0DD2836DC232F06B /* Frameworks */,
+				E1DB8386CFBB095483FF5CE3 /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -495,12 +667,12 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = DA1A10EB1D0101ED009F82FA /* Build configuration list for PBXNativeTarget "MapboxDirectionsTVTests" */;
 			buildPhases = (
-				CD85FC2E11CA2407E470D96A /* [CP] Check Pods Manifest.lock */,
+				B3DDF3F3F716B1F3E1672556 /* [CP] Check Pods Manifest.lock */,
 				DA1A10DA1D0101ED009F82FA /* Sources */,
 				DA1A10DC1D0101ED009F82FA /* Resources */,
-				8B356E95C84C71D8931B9BD7 /* [CP] Embed Pods Frameworks */,
-				5B78A86D5148CEF869D231A2 /* [CP] Copy Pods Resources */,
 				92F37F617F04E042D4413B37 /* Frameworks */,
+				40E61C63D7091CB0D1F1A44B /* [CP] Embed Pods Frameworks */,
+				9CAABF965007147D98CA5B65 /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -516,12 +688,12 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = DA1A11001D010361009F82FA /* Build configuration list for PBXNativeTarget "MapboxDirectionsWatch" */;
 			buildPhases = (
-				07C84EC32D42BAAC60602686 /* [CP] Check Pods Manifest.lock */,
+				1A2F61D4EF6AC85449FEB14B /* [CP] Check Pods Manifest.lock */,
 				DA1A10F61D010361009F82FA /* Sources */,
 				DA1A10F81D010361009F82FA /* Headers */,
 				DA1A10F91D010361009F82FA /* Resources */,
-				0B57D6255DFAC3A0B6EE502B /* [CP] Copy Pods Resources */,
 				E05B24A0DFB05E8378736C51 /* Frameworks */,
+				7E98AF22895E0A888E7E0FED /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -536,12 +708,12 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = DA6C9DA01CAE442B00094FBC /* Build configuration list for PBXNativeTarget "MapboxDirections" */;
 			buildPhases = (
-				50BC72292C3221BA6A7C67DE /* [CP] Check Pods Manifest.lock */,
+				5490BEBC50EC121D9F6DF184 /* [CP] Check Pods Manifest.lock */,
 				DA6C9D831CAE442B00094FBC /* Sources */,
 				DA6C9D851CAE442B00094FBC /* Headers */,
 				DA6C9D861CAE442B00094FBC /* Resources */,
-				8B7DE670CE92B01F4B1F67BF /* [CP] Copy Pods Resources */,
 				7AC435C54F754F3C6A047D02 /* Frameworks */,
+				63C3A09E1A08D1870328629F /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -556,12 +728,12 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = DA6C9DA31CAE442B00094FBC /* Build configuration list for PBXNativeTarget "MapboxDirectionsTests" */;
 			buildPhases = (
-				EB3198293BE24BD38714B691 /* [CP] Check Pods Manifest.lock */,
+				B22A509CF5AF87D05EB0A8FA /* [CP] Check Pods Manifest.lock */,
 				DA6C9D8D1CAE442B00094FBC /* Sources */,
 				DA6C9D8F1CAE442B00094FBC /* Resources */,
-				058586A3DA3BA3FDC8F9F235 /* [CP] Embed Pods Frameworks */,
-				4697D852B9665CF89108CE7B /* [CP] Copy Pods Resources */,
 				41F7A758F36CA42614E9759D /* Frameworks */,
+				1D8FA0114F6A80B506012121 /* [CP] Embed Pods Frameworks */,
+				13215E58DCFF5725A78316F5 /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -582,13 +754,15 @@
 				DD62544B1AE70C1700017857 /* Frameworks */,
 				DD62544C1AE70C1700017857 /* Resources */,
 				DA1A11151D011089009F82FA /* Embed Frameworks */,
-				1AB304E29E6C33609AE5AE1A /* [CP] Embed Pods Frameworks */,
-				42B8F2A93E9D04F9BBE2A512 /* [CP] Copy Pods Resources */,
+				DA15B1C21D5D501500C8042B /* Embed Watch Content */,
+				A5A9C1B570F795C42DC79EDB /* [CP] Embed Pods Frameworks */,
+				B595302C599A3B84ABF26AEC /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
 			dependencies = (
 				DA1A11141D011089009F82FA /* PBXTargetDependency */,
+				DA15B1B91D5D501500C8042B /* PBXTargetDependency */,
 			);
 			name = "Example (Swift)";
 			productName = "Directions Example";
@@ -602,33 +776,49 @@
 			isa = PBXProject;
 			attributes = {
 				LastSwiftMigration = 0700;
-				LastSwiftUpdateCheck = 0730;
+				LastSwiftUpdateCheck = 0800;
 				LastUpgradeCheck = 0700;
 				ORGANIZATIONNAME = Mapbox;
 				TargetAttributes = {
+					DA15B19B1D5D501500C8042B = {
+						CreatedOnToolsVersion = 8.0;
+						ProvisioningStyle = Automatic;
+					};
+					DA15B1A71D5D501500C8042B = {
+						CreatedOnToolsVersion = 8.0;
+						ProvisioningStyle = Automatic;
+					};
 					DA1A10AE1D00F8FF009F82FA = {
 						CreatedOnToolsVersion = 7.3.1;
+						LastSwiftMigration = 0800;
 					};
 					DA1A10B71D00F8FF009F82FA = {
 						CreatedOnToolsVersion = 7.3.1;
+						LastSwiftMigration = 0800;
 					};
 					DA1A10D41D0101ED009F82FA = {
 						CreatedOnToolsVersion = 7.3.1;
+						LastSwiftMigration = 0800;
 					};
 					DA1A10DD1D0101ED009F82FA = {
 						CreatedOnToolsVersion = 7.3.1;
+						LastSwiftMigration = 0800;
 					};
 					DA1A10FA1D010361009F82FA = {
 						CreatedOnToolsVersion = 7.3.1;
+						LastSwiftMigration = 0800;
 					};
 					DA6C9D871CAE442B00094FBC = {
 						CreatedOnToolsVersion = 7.3;
+						LastSwiftMigration = 0800;
 					};
 					DA6C9D901CAE442B00094FBC = {
 						CreatedOnToolsVersion = 7.3;
+						LastSwiftMigration = 0800;
 					};
 					DD62544D1AE70C1700017857 = {
 						CreatedOnToolsVersion = 6.3;
+						LastSwiftMigration = 0800;
 					};
 				};
 			};
@@ -653,11 +843,30 @@
 				DA1A10D41D0101ED009F82FA /* MapboxDirectionsTV */,
 				DA1A10DD1D0101ED009F82FA /* MapboxDirectionsTVTests */,
 				DA1A10FA1D010361009F82FA /* MapboxDirectionsWatch */,
+				DA15B19B1D5D501500C8042B /* WatchExample */,
+				DA15B1A71D5D501500C8042B /* WatchExample Extension */,
 			);
 		};
 /* End PBXProject section */
 
 /* Begin PBXResourcesBuildPhase section */
+		DA15B19A1D5D501500C8042B /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				DA15B1A21D5D501500C8042B /* Assets.xcassets in Resources */,
+				DA15B1A01D5D501500C8042B /* Interface.storyboard in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		DA15B1A61D5D501500C8042B /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				DA15B1B61D5D501500C8042B /* Assets.xcassets in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		DA1A10AD1D00F8FF009F82FA /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -729,22 +938,7 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
-		058586A3DA3BA3FDC8F9F235 /* [CP] Embed Pods Frameworks */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = "[CP] Embed Pods Frameworks";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-MapboxDirectionsTests/Pods-MapboxDirectionsTests-frameworks.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
-		07C84EC32D42BAAC60602686 /* [CP] Check Pods Manifest.lock */ = {
+		07EB541A056F200DC7890508 /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -756,85 +950,10 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [[ $? != 0 ]] ; then\n    cat << EOM\nerror: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\nEOM\n    exit 1\nfi\n";
+			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n";
 			showEnvVarsInLog = 0;
 		};
-		0B57D6255DFAC3A0B6EE502B /* [CP] Copy Pods Resources */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = "[CP] Copy Pods Resources";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-MapboxDirectionsWatch/Pods-MapboxDirectionsWatch-resources.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
-		1AB304E29E6C33609AE5AE1A /* [CP] Embed Pods Frameworks */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = "[CP] Embed Pods Frameworks";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-Example (Swift)/Pods-Example (Swift)-frameworks.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
-		31D6B942299D49FEB7DF0BA7 /* [CP] Embed Pods Frameworks */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = "[CP] Embed Pods Frameworks";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-MapboxDirectionsMacTests/Pods-MapboxDirectionsMacTests-frameworks.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
-		422B38CA821F5EA5A289825D /* [CP] Check Pods Manifest.lock */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = "[CP] Check Pods Manifest.lock";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [[ $? != 0 ]] ; then\n    cat << EOM\nerror: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\nEOM\n    exit 1\nfi\n";
-			showEnvVarsInLog = 0;
-		};
-		42B8F2A93E9D04F9BBE2A512 /* [CP] Copy Pods Resources */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = "[CP] Copy Pods Resources";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-Example (Swift)/Pods-Example (Swift)-resources.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
-		4697D852B9665CF89108CE7B /* [CP] Copy Pods Resources */ = {
+		13215E58DCFF5725A78316F5 /* [CP] Copy Pods Resources */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -849,7 +968,7 @@
 			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-MapboxDirectionsTests/Pods-MapboxDirectionsTests-resources.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
-		50BC72292C3221BA6A7C67DE /* [CP] Check Pods Manifest.lock */ = {
+		164BE52AA118E9B230A12CB4 /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -861,40 +980,10 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [[ $? != 0 ]] ; then\n    cat << EOM\nerror: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\nEOM\n    exit 1\nfi\n";
+			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n";
 			showEnvVarsInLog = 0;
 		};
-		5B78A86D5148CEF869D231A2 /* [CP] Copy Pods Resources */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = "[CP] Copy Pods Resources";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-MapboxDirectionsTVTests/Pods-MapboxDirectionsTVTests-resources.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
-		62F2CAEB1090FB9B4C74443A /* [CP] Copy Pods Resources */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = "[CP] Copy Pods Resources";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-MapboxDirectionsMacTests/Pods-MapboxDirectionsMacTests-resources.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
-		645B8814CE6BF41CF300B389 /* [CP] Check Pods Manifest.lock */ = {
+		1A2F61D4EF6AC85449FEB14B /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -906,40 +995,10 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [[ $? != 0 ]] ; then\n    cat << EOM\nerror: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\nEOM\n    exit 1\nfi\n";
+			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n";
 			showEnvVarsInLog = 0;
 		};
-		65B9BC290124777B27A8EE0C /* [CP] Check Pods Manifest.lock */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = "[CP] Check Pods Manifest.lock";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [[ $? != 0 ]] ; then\n    cat << EOM\nerror: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\nEOM\n    exit 1\nfi\n";
-			showEnvVarsInLog = 0;
-		};
-		7C73FD970881BDE62B7A76B2 /* [CP] Check Pods Manifest.lock */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = "[CP] Check Pods Manifest.lock";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [[ $? != 0 ]] ; then\n    cat << EOM\nerror: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\nEOM\n    exit 1\nfi\n";
-			showEnvVarsInLog = 0;
-		};
-		8B356E95C84C71D8931B9BD7 /* [CP] Embed Pods Frameworks */ = {
+		1D8FA0114F6A80B506012121 /* [CP] Embed Pods Frameworks */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -951,40 +1010,25 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-MapboxDirectionsTVTests/Pods-MapboxDirectionsTVTests-frameworks.sh\"\n";
+			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-MapboxDirectionsTests/Pods-MapboxDirectionsTests-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
-		8B7DE670CE92B01F4B1F67BF /* [CP] Copy Pods Resources */ = {
+		23C21BECDCC715D9124A5E09 /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			inputPaths = (
 			);
-			name = "[CP] Copy Pods Resources";
+			name = "[CP] Check Pods Manifest.lock";
 			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-MapboxDirections/Pods-MapboxDirections-resources.sh\"\n";
+			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n";
 			showEnvVarsInLog = 0;
 		};
-		9969583F2E1AC2D68717395B /* [CP] Copy Pods Resources */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = "[CP] Copy Pods Resources";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-MapboxDirectionsTV/Pods-MapboxDirectionsTV-resources.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
-		A7AA2C0E4B916A0B8CE44754 /* [CP] Copy Pods Resources */ = {
+		2A512AB2F5C1E6C58DEF5E51 /* [CP] Copy Pods Resources */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -999,22 +1043,22 @@
 			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-MapboxDirectionsMac/Pods-MapboxDirectionsMac-resources.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
-		CD85FC2E11CA2407E470D96A /* [CP] Check Pods Manifest.lock */ = {
+		40E61C63D7091CB0D1F1A44B /* [CP] Embed Pods Frameworks */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			inputPaths = (
 			);
-			name = "[CP] Check Pods Manifest.lock";
+			name = "[CP] Embed Pods Frameworks";
 			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [[ $? != 0 ]] ; then\n    cat << EOM\nerror: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\nEOM\n    exit 1\nfi\n";
+			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-MapboxDirectionsTVTests/Pods-MapboxDirectionsTVTests-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
-		EB3198293BE24BD38714B691 /* [CP] Check Pods Manifest.lock */ = {
+		5490BEBC50EC121D9F6DF184 /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -1026,12 +1070,217 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [[ $? != 0 ]] ; then\n    cat << EOM\nerror: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\nEOM\n    exit 1\nfi\n";
+			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n";
+			showEnvVarsInLog = 0;
+		};
+		63C3A09E1A08D1870328629F /* [CP] Copy Pods Resources */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "[CP] Copy Pods Resources";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-MapboxDirections/Pods-MapboxDirections-resources.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		690FF18CD3B69F7D8CD139CC /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n";
+			showEnvVarsInLog = 0;
+		};
+		6BC16E4F89B70B99A5E06E71 /* [CP] Copy Pods Resources */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "[CP] Copy Pods Resources";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-WatchExample/Pods-WatchExample-resources.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		7C73FD970881BDE62B7A76B2 /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n";
+			showEnvVarsInLog = 0;
+		};
+		7E98AF22895E0A888E7E0FED /* [CP] Copy Pods Resources */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "[CP] Copy Pods Resources";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-MapboxDirectionsWatch/Pods-MapboxDirectionsWatch-resources.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		9CAABF965007147D98CA5B65 /* [CP] Copy Pods Resources */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "[CP] Copy Pods Resources";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-MapboxDirectionsTVTests/Pods-MapboxDirectionsTVTests-resources.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		A5A9C1B570F795C42DC79EDB /* [CP] Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "[CP] Embed Pods Frameworks";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-Example (Swift)/Pods-Example (Swift)-frameworks.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		B146922AAE71DC82A56BBA60 /* [CP] Copy Pods Resources */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "[CP] Copy Pods Resources";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-MapboxDirectionsMacTests/Pods-MapboxDirectionsMacTests-resources.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		B22A509CF5AF87D05EB0A8FA /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n";
+			showEnvVarsInLog = 0;
+		};
+		B3DDF3F3F716B1F3E1672556 /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n";
+			showEnvVarsInLog = 0;
+		};
+		B595302C599A3B84ABF26AEC /* [CP] Copy Pods Resources */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "[CP] Copy Pods Resources";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-Example (Swift)/Pods-Example (Swift)-resources.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		CA9D333DD4D637ED30DA1B5D /* [CP] Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "[CP] Embed Pods Frameworks";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-MapboxDirectionsMacTests/Pods-MapboxDirectionsMacTests-frameworks.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		E1DB8386CFBB095483FF5CE3 /* [CP] Copy Pods Resources */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "[CP] Copy Pods Resources";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-MapboxDirectionsTV/Pods-MapboxDirectionsTV-resources.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 /* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
+		DA15B1A41D5D501500C8042B /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				DA15B1B41D5D501500C8042B /* NotificationController.swift in Sources */,
+				DA15B1B21D5D501500C8042B /* ExtensionDelegate.swift in Sources */,
+				DA15B1B01D5D501500C8042B /* InterfaceController.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		DA1A10AA1D00F8FF009F82FA /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -1129,6 +1378,21 @@
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
+		DA15B1AB1D5D501500C8042B /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = DA15B1A71D5D501500C8042B /* WatchExample Extension */;
+			targetProxy = DA15B1AA1D5D501500C8042B /* PBXContainerItemProxy */;
+		};
+		DA15B1B91D5D501500C8042B /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = DA15B19B1D5D501500C8042B /* WatchExample */;
+			targetProxy = DA15B1B81D5D501500C8042B /* PBXContainerItemProxy */;
+		};
+		DA15B1C61D5D502900C8042B /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = DA1A10FA1D010361009F82FA /* MapboxDirectionsWatch */;
+			targetProxy = DA15B1C51D5D502900C8042B /* PBXContainerItemProxy */;
+		};
 		DA1A10BB1D00F8FF009F82FA /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			target = DA1A10AE1D00F8FF009F82FA /* MapboxDirectionsMac */;
@@ -1151,10 +1415,113 @@
 		};
 /* End PBXTargetDependency section */
 
+/* Begin PBXVariantGroup section */
+		DA15B19E1D5D501500C8042B /* Interface.storyboard */ = {
+			isa = PBXVariantGroup;
+			children = (
+				DA15B19F1D5D501500C8042B /* Base */,
+			);
+			name = Interface.storyboard;
+			sourceTree = "<group>";
+		};
+/* End PBXVariantGroup section */
+
 /* Begin XCBuildConfiguration section */
+		DA15B1BB1D5D501500C8042B /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 7AB05E29E43D55326F7FA67B /* Pods-WatchExample.debug.xcconfig */;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_SUSPICIOUS_MOVES = YES;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				IBSC_MODULE = WatchExample_Extension;
+				INFOPLIST_FILE = WatchExample/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = com.mapbox.MapboxDirectionsExample.swift.watchkitapp;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = watchos;
+				SKIP_INSTALL = YES;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_VERSION = 2.3;
+				TARGETED_DEVICE_FAMILY = 4;
+				WATCHOS_DEPLOYMENT_TARGET = 2.0;
+			};
+			name = Debug;
+		};
+		DA15B1BC1D5D501500C8042B /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 05045275F3647340E9698D26 /* Pods-WatchExample.release.xcconfig */;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_SUSPICIOUS_MOVES = YES;
+				IBSC_MODULE = WatchExample_Extension;
+				INFOPLIST_FILE = WatchExample/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = com.mapbox.MapboxDirectionsExample.swift.watchkitapp;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = watchos;
+				SKIP_INSTALL = YES;
+				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
+				SWIFT_VERSION = 2.3;
+				TARGETED_DEVICE_FAMILY = 4;
+				WATCHOS_DEPLOYMENT_TARGET = 2.0;
+			};
+			name = Release;
+		};
+		DA15B1BD1D5D501500C8042B /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_COMPLICATION_NAME = Complication;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_SUSPICIOUS_MOVES = YES;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				INFOPLIST_FILE = "WatchExample Extension/Info.plist";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @executable_path/../../Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = com.mapbox.MapboxDirectionsExample.swift.watchkitapp.watchkitextension;
+				PRODUCT_NAME = "${TARGET_NAME}";
+				SDKROOT = watchos;
+				SKIP_INSTALL = YES;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_VERSION = 2.3;
+				TARGETED_DEVICE_FAMILY = 4;
+				WATCHOS_DEPLOYMENT_TARGET = 2.0;
+			};
+			name = Debug;
+		};
+		DA15B1BE1D5D501500C8042B /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_COMPLICATION_NAME = Complication;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_SUSPICIOUS_MOVES = YES;
+				INFOPLIST_FILE = "WatchExample Extension/Info.plist";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @executable_path/../../Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = com.mapbox.MapboxDirectionsExample.swift.watchkitapp.watchkitextension;
+				PRODUCT_NAME = "${TARGET_NAME}";
+				SDKROOT = watchos;
+				SKIP_INSTALL = YES;
+				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
+				SWIFT_VERSION = 2.3;
+				TARGETED_DEVICE_FAMILY = 4;
+				WATCHOS_DEPLOYMENT_TARGET = 2.0;
+			};
+			name = Release;
+		};
 		DA1A10C01D00F8FF009F82FA /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 3A3200DC60F96A1525D1916C /* Pods-MapboxDirectionsMac.debug.xcconfig */;
+			baseConfigurationReference = B138892B1F6A8960575D68D6 /* Pods-MapboxDirectionsMac.debug.xcconfig */;
 			buildSettings = {
 				CLANG_ANALYZER_NONNULL = YES;
 				CODE_SIGN_IDENTITY = "-";
@@ -1173,6 +1540,7 @@
 				PRODUCT_NAME = MapboxDirections;
 				SDKROOT = macosx;
 				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 2.3;
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
 			};
@@ -1180,7 +1548,7 @@
 		};
 		DA1A10C11D00F8FF009F82FA /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 26F4C3A5D5ABF163E53BBAAE /* Pods-MapboxDirectionsMac.release.xcconfig */;
+			baseConfigurationReference = 0E54F34CE80B8FAA8A8237AF /* Pods-MapboxDirectionsMac.release.xcconfig */;
 			buildSettings = {
 				CLANG_ANALYZER_NONNULL = YES;
 				CODE_SIGN_IDENTITY = "-";
@@ -1198,6 +1566,7 @@
 				PRODUCT_NAME = MapboxDirections;
 				SDKROOT = macosx;
 				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 2.3;
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
 			};
@@ -1205,7 +1574,7 @@
 		};
 		DA1A10C21D00F8FF009F82FA /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = FB735824DBD14927E8AC411B /* Pods-MapboxDirectionsMacTests.debug.xcconfig */;
+			baseConfigurationReference = C5216CD064790304C0D12E08 /* Pods-MapboxDirectionsMacTests.debug.xcconfig */;
 			buildSettings = {
 				CLANG_ANALYZER_NONNULL = YES;
 				CODE_SIGN_IDENTITY = "-";
@@ -1216,12 +1585,13 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.mapbox.MapboxDirectionsTests;
 				PRODUCT_NAME = MapboxDirectionsTests;
 				SDKROOT = macosx;
+				SWIFT_VERSION = 2.3;
 			};
 			name = Debug;
 		};
 		DA1A10C31D00F8FF009F82FA /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = D6B9D6C6A2118801E17F73AC /* Pods-MapboxDirectionsMacTests.release.xcconfig */;
+			baseConfigurationReference = 7E3FF4F9120D6C9E60708335 /* Pods-MapboxDirectionsMacTests.release.xcconfig */;
 			buildSettings = {
 				CLANG_ANALYZER_NONNULL = YES;
 				CODE_SIGN_IDENTITY = "-";
@@ -1231,12 +1601,13 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.mapbox.MapboxDirectionsTests;
 				PRODUCT_NAME = MapboxDirectionsTests;
 				SDKROOT = macosx;
+				SWIFT_VERSION = 2.3;
 			};
 			name = Release;
 		};
 		DA1A10E61D0101ED009F82FA /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 0FD4719FAB56964485A4E090 /* Pods-MapboxDirectionsTV.debug.xcconfig */;
+			baseConfigurationReference = E32FD2E0FD00A2CAF23B8BBD /* Pods-MapboxDirectionsTV.debug.xcconfig */;
 			buildSettings = {
 				CLANG_ANALYZER_NONNULL = YES;
 				CURRENT_PROJECT_VERSION = 2;
@@ -1252,6 +1623,7 @@
 				PRODUCT_NAME = MapboxDirections;
 				SDKROOT = appletvos;
 				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 2.3;
 				TARGETED_DEVICE_FAMILY = 3;
 				TVOS_DEPLOYMENT_TARGET = 9.0;
 				VERSIONING_SYSTEM = "apple-generic";
@@ -1261,7 +1633,7 @@
 		};
 		DA1A10E71D0101ED009F82FA /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 844B8A6B18AB25E1ED023074 /* Pods-MapboxDirectionsTV.release.xcconfig */;
+			baseConfigurationReference = 45D272931D93A2185C1F3140 /* Pods-MapboxDirectionsTV.release.xcconfig */;
 			buildSettings = {
 				CLANG_ANALYZER_NONNULL = YES;
 				CURRENT_PROJECT_VERSION = 2;
@@ -1276,6 +1648,7 @@
 				PRODUCT_NAME = MapboxDirections;
 				SDKROOT = appletvos;
 				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 2.3;
 				TARGETED_DEVICE_FAMILY = 3;
 				TVOS_DEPLOYMENT_TARGET = 9.0;
 				VERSIONING_SYSTEM = "apple-generic";
@@ -1285,7 +1658,7 @@
 		};
 		DA1A10E81D0101ED009F82FA /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 6ED1E050D32520EDBDD3D372 /* Pods-MapboxDirectionsTVTests.debug.xcconfig */;
+			baseConfigurationReference = BEAF6404FB359F49700E9114 /* Pods-MapboxDirectionsTVTests.debug.xcconfig */;
 			buildSettings = {
 				CLANG_ANALYZER_NONNULL = YES;
 				DEBUG_INFORMATION_FORMAT = dwarf;
@@ -1294,13 +1667,14 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.mapbox.MapboxDirectionsTests;
 				PRODUCT_NAME = MapboxDirectionsTests;
 				SDKROOT = appletvos;
+				SWIFT_VERSION = 2.3;
 				TVOS_DEPLOYMENT_TARGET = 9.0;
 			};
 			name = Debug;
 		};
 		DA1A10E91D0101ED009F82FA /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = F59A464651694E5ECFA36D60 /* Pods-MapboxDirectionsTVTests.release.xcconfig */;
+			baseConfigurationReference = D39D92434CEA7E755F68A0DD /* Pods-MapboxDirectionsTVTests.release.xcconfig */;
 			buildSettings = {
 				CLANG_ANALYZER_NONNULL = YES;
 				INFOPLIST_FILE = MapboxDirectionsTests/Info.plist;
@@ -1308,13 +1682,14 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.mapbox.MapboxDirectionsTests;
 				PRODUCT_NAME = MapboxDirectionsTests;
 				SDKROOT = appletvos;
+				SWIFT_VERSION = 2.3;
 				TVOS_DEPLOYMENT_TARGET = 9.0;
 			};
 			name = Release;
 		};
 		DA1A11011D010361009F82FA /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = EC7AF27DBE65271A314C18B6 /* Pods-MapboxDirectionsWatch.debug.xcconfig */;
+			baseConfigurationReference = 2E1E30C7261B1CC9E446EF14 /* Pods-MapboxDirectionsWatch.debug.xcconfig */;
 			buildSettings = {
 				APPLICATION_EXTENSION_API_ONLY = YES;
 				CLANG_ANALYZER_NONNULL = YES;
@@ -1331,6 +1706,7 @@
 				PRODUCT_NAME = MapboxDirections;
 				SDKROOT = watchos;
 				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 2.3;
 				TARGETED_DEVICE_FAMILY = 4;
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
@@ -1340,7 +1716,7 @@
 		};
 		DA1A11021D010361009F82FA /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 0C59B42BC819E63045BBE9A8 /* Pods-MapboxDirectionsWatch.release.xcconfig */;
+			baseConfigurationReference = 14A212D3093A6B2F16C5906B /* Pods-MapboxDirectionsWatch.release.xcconfig */;
 			buildSettings = {
 				APPLICATION_EXTENSION_API_ONLY = YES;
 				CLANG_ANALYZER_NONNULL = YES;
@@ -1356,6 +1732,7 @@
 				PRODUCT_NAME = MapboxDirections;
 				SDKROOT = watchos;
 				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 2.3;
 				TARGETED_DEVICE_FAMILY = 4;
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
@@ -1365,7 +1742,7 @@
 		};
 		DA6C9DA11CAE442B00094FBC /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 7F5C6C4953282E544499886B /* Pods-MapboxDirections.debug.xcconfig */;
+			baseConfigurationReference = 3CBDF466DA79A0300E88AA8C /* Pods-MapboxDirections.debug.xcconfig */;
 			buildSettings = {
 				CLANG_ANALYZER_NONNULL = YES;
 				CURRENT_PROJECT_VERSION = 2;
@@ -1380,6 +1757,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.mapbox.MapboxDirections;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 2.3;
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
 			};
@@ -1387,7 +1765,7 @@
 		};
 		DA6C9DA21CAE442B00094FBC /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 52BAF0302AAF3051E5A31D2F /* Pods-MapboxDirections.release.xcconfig */;
+			baseConfigurationReference = F91F172DFB1E0945243533D7 /* Pods-MapboxDirections.release.xcconfig */;
 			buildSettings = {
 				CLANG_ANALYZER_NONNULL = YES;
 				CURRENT_PROJECT_VERSION = 2;
@@ -1401,6 +1779,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.mapbox.MapboxDirections;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 2.3;
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
 			};
@@ -1408,7 +1787,7 @@
 		};
 		DA6C9DA41CAE442B00094FBC /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 982B076C0E044A2F180CE50D /* Pods-MapboxDirectionsTests.debug.xcconfig */;
+			baseConfigurationReference = 46B778CDD353A9BEFD44A098 /* Pods-MapboxDirectionsTests.debug.xcconfig */;
 			buildSettings = {
 				CLANG_ANALYZER_NONNULL = YES;
 				DEBUG_INFORMATION_FORMAT = dwarf;
@@ -1417,12 +1796,13 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited)";
 				PRODUCT_BUNDLE_IDENTIFIER = com.mapbox.MapboxDirectionsTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 2.3;
 			};
 			name = Debug;
 		};
 		DA6C9DA51CAE442B00094FBC /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 8742F3B5D746590C8C2FA4CA /* Pods-MapboxDirectionsTests.release.xcconfig */;
+			baseConfigurationReference = B215B2487667504F84228843 /* Pods-MapboxDirectionsTests.release.xcconfig */;
 			buildSettings = {
 				CLANG_ANALYZER_NONNULL = YES;
 				INFOPLIST_FILE = MapboxDirectionsTests/Info.plist;
@@ -1430,6 +1810,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited)";
 				PRODUCT_BUNDLE_IDENTIFIER = com.mapbox.MapboxDirectionsTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 2.3;
 			};
 			name = Release;
 		};
@@ -1521,29 +1902,49 @@
 		};
 		DD62546E1AE70C1700017857 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 41AC8B888A90DD5CDAE8E86F /* Pods-Example (Swift).debug.xcconfig */;
+			baseConfigurationReference = 280512B2AFE7777BE47B598C /* Pods-Example (Swift).debug.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				INFOPLIST_FILE = "Directions Example/Info.plist";
 				PRODUCT_BUNDLE_IDENTIFIER = com.mapbox.MapboxDirectionsExample.swift;
 				PRODUCT_NAME = "Directions (Swift)";
+				SWIFT_VERSION = 2.3;
 			};
 			name = Debug;
 		};
 		DD62546F1AE70C1700017857 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = EDF0BB33D58A513BC08576AA /* Pods-Example (Swift).release.xcconfig */;
+			baseConfigurationReference = 5ABC95CC4D6BF3BCA6667F5C /* Pods-Example (Swift).release.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				INFOPLIST_FILE = "Directions Example/Info.plist";
 				PRODUCT_BUNDLE_IDENTIFIER = com.mapbox.MapboxDirectionsExample.swift;
 				PRODUCT_NAME = "Directions (Swift)";
+				SWIFT_VERSION = 2.3;
 			};
 			name = Release;
 		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
+		DA15B1BF1D5D501500C8042B /* Build configuration list for PBXNativeTarget "WatchExample Extension" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				DA15B1BD1D5D501500C8042B /* Debug */,
+				DA15B1BE1D5D501500C8042B /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		DA15B1C11D5D501500C8042B /* Build configuration list for PBXNativeTarget "WatchExample" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				DA15B1BB1D5D501500C8042B /* Debug */,
+				DA15B1BC1D5D501500C8042B /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
 		DA1A10C41D00F8FF009F82FA /* Build configuration list for PBXNativeTarget "MapboxDirectionsMac" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (

--- a/Podfile
+++ b/Podfile
@@ -6,7 +6,7 @@ end
 
 def shared_test_pods
   shared_pods
-  pod 'OHHTTPStubs/Swift', '~> 5.0.0', :configurations => ['Debug']
+  pod 'OHHTTPStubs/Swift', :git => 'https://github.com/AliSoftware/OHHTTPStubs.git', :commit => '4995ecd762abdd81227d14faf65fde003fbbe789', :configurations => ['Debug']
 end
 
 target 'MapboxDirections' do
@@ -48,4 +48,8 @@ target 'Example (Swift)' do
   platform :ios, '8.0'
   shared_pods
   pod 'Mapbox-iOS-SDK', '~> 3.3'
+end
+
+target 'WatchExample' do
+  platform :watchos, '2.0'
 end

--- a/README.md
+++ b/README.md
@@ -238,3 +238,5 @@ To run the included unit tests, you need to use [CocoaPods](http://cocoapods.org
 1. `pod install`
 1. `open MapboxDirections.xcworkspace`
 1. Switch to the MapboxDirections scheme and go to Product ‣ Test.
+
+The workspace requires CocoaPods 1.1.0.beta.1 or greater if opening inside Xcode 8.

--- a/WatchExample Extension/Assets.xcassets/Complication.complicationset/Circular.imageset/Contents.json
+++ b/WatchExample Extension/Assets.xcassets/Complication.complicationset/Circular.imageset/Contents.json
@@ -1,0 +1,18 @@
+{
+  "images" : [
+    {
+      "idiom" : "watch",
+      "screenWidth" : "{130,145}",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "watch",
+      "screenWidth" : "{146,165}",
+      "scale" : "2x"
+    }
+  ],
+  "info" : {
+    "version" : 1,
+    "author" : "xcode"
+  }
+}

--- a/WatchExample Extension/Assets.xcassets/Complication.complicationset/Contents.json
+++ b/WatchExample Extension/Assets.xcassets/Complication.complicationset/Contents.json
@@ -1,0 +1,23 @@
+{
+  "assets" : [
+    {
+      "idiom" : "watch",
+      "filename" : "Circular.imageset",
+      "role" : "circular"
+    },
+    {
+      "idiom" : "watch",
+      "filename" : "Modular.imageset",
+      "role" : "modular"
+    },
+    {
+      "idiom" : "watch",
+      "filename" : "Utilitarian.imageset",
+      "role" : "utilitarian"
+    }
+  ],
+  "info" : {
+    "version" : 1,
+    "author" : "xcode"
+  }
+}

--- a/WatchExample Extension/Assets.xcassets/Complication.complicationset/Modular.imageset/Contents.json
+++ b/WatchExample Extension/Assets.xcassets/Complication.complicationset/Modular.imageset/Contents.json
@@ -1,0 +1,18 @@
+{
+  "images" : [
+    {
+      "idiom" : "watch",
+      "screenWidth" : "{130,145}",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "watch",
+      "screenWidth" : "{146,165}",
+      "scale" : "2x"
+    }
+  ],
+  "info" : {
+    "version" : 1,
+    "author" : "xcode"
+  }
+}

--- a/WatchExample Extension/Assets.xcassets/Complication.complicationset/Utilitarian.imageset/Contents.json
+++ b/WatchExample Extension/Assets.xcassets/Complication.complicationset/Utilitarian.imageset/Contents.json
@@ -1,0 +1,18 @@
+{
+  "images" : [
+    {
+      "idiom" : "watch",
+      "screenWidth" : "{130,145}",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "watch",
+      "screenWidth" : "{146,165}",
+      "scale" : "2x"
+    }
+  ],
+  "info" : {
+    "version" : 1,
+    "author" : "xcode"
+  }
+}

--- a/WatchExample Extension/ExtensionDelegate.swift
+++ b/WatchExample Extension/ExtensionDelegate.swift
@@ -1,0 +1,18 @@
+import WatchKit
+
+class ExtensionDelegate: NSObject, WKExtensionDelegate {
+
+    func applicationDidFinishLaunching() {
+        // Perform any final initialization of your application.
+    }
+
+    func applicationDidBecomeActive() {
+        // Restart any tasks that were paused (or not yet started) while the application was inactive. If the application was previously in the background, optionally refresh the user interface.
+    }
+
+    func applicationWillResignActive() {
+        // Sent when the application is about to move from active to inactive state. This can occur for certain types of temporary interruptions (such as an incoming phone call or SMS message) or when the user quits the application and it begins the transition to the background state.
+        // Use this method to pause ongoing tasks, disable timers, etc.
+    }
+
+}

--- a/WatchExample Extension/Info.plist
+++ b/WatchExample Extension/Info.plist
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleDisplayName</key>
+	<string>WatchExample Extension</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>XPC!</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+	<key>NSExtension</key>
+	<dict>
+		<key>NSExtensionAttributes</key>
+		<dict>
+			<key>WKAppBundleIdentifier</key>
+			<string>com.mapbox.MapboxDirectionsExample.swift.watchkitapp</string>
+		</dict>
+		<key>NSExtensionPointIdentifier</key>
+		<string>com.apple.watchkit</string>
+	</dict>
+	<key>WKExtensionDelegateClassName</key>
+	<string>$(PRODUCT_MODULE_NAME).ExtensionDelegate</string>
+</dict>
+</plist>

--- a/WatchExample Extension/InterfaceController.swift
+++ b/WatchExample Extension/InterfaceController.swift
@@ -1,0 +1,23 @@
+import WatchKit
+import Foundation
+
+
+class InterfaceController: WKInterfaceController {
+
+    override func awakeWithContext(context: AnyObject?) {
+        super.awakeWithContext(context)
+        
+        // Configure interface objects here.
+    }
+    
+    override func willActivate() {
+        // This method is called when watch view controller is about to be visible to user
+        super.willActivate()
+    }
+    
+    override func didDeactivate() {
+        // This method is called when watch view controller is no longer visible
+        super.didDeactivate()
+    }
+
+}

--- a/WatchExample Extension/NotificationController.swift
+++ b/WatchExample Extension/NotificationController.swift
@@ -1,0 +1,35 @@
+import WatchKit
+import Foundation
+import UserNotifications
+
+
+class NotificationController: WKUserNotificationInterfaceController {
+
+    override init() {
+        // Initialize variables here.
+        super.init()
+        
+        // Configure interface objects here.
+    }
+
+    override func willActivate() {
+        // This method is called when watch view controller is about to be visible to user
+        super.willActivate()
+    }
+
+    override func didDeactivate() {
+        // This method is called when watch view controller is no longer visible
+        super.didDeactivate()
+    }
+
+    /*
+    override func didReceiveNotification(notification: UNNotification, withCompletion completionHandler: (WKUserNotificationInterfaceType) -> Void) {
+        // This method is called when a notification needs to be presented.
+        // Implement it if you use a dynamic notification interface.
+        // Populate your dynamic notification interface as quickly as possible.
+        //
+        // After populating your dynamic notification interface call the completion block.
+        completionHandler(.custom)
+    }
+    */
+}

--- a/WatchExample Extension/NotificationController.swift
+++ b/WatchExample Extension/NotificationController.swift
@@ -1,7 +1,5 @@
 import WatchKit
 import Foundation
-import UserNotifications
-
 
 class NotificationController: WKUserNotificationInterfaceController {
 

--- a/WatchExample Extension/PushNotificationPayload.apns
+++ b/WatchExample Extension/PushNotificationPayload.apns
@@ -1,0 +1,18 @@
+{
+    "aps": {
+        "alert": {
+            "body": "Test message",
+            "title": "Optional title"
+        },
+        "category": "myCategory"
+    },
+    
+    "WatchKit Simulator Actions": [
+        {
+            "title": "First Button",
+            "identifier": "firstButtonAction"
+        }
+    ],
+    
+    "customKey": "Use this file to define a testing payload for your notifications. The aps dictionary specifies the category, alert text and title. The WatchKit Simulator Actions array can provide info for one or more action buttons in addition to the standard Dismiss button. Any other top level keys are custom payload. If you have multiple such JSON files in your project, you'll be able to select them when choosing to debug the notification interface of your Watch App."
+}

--- a/WatchExample/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/WatchExample/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -1,0 +1,55 @@
+{
+  "images" : [
+    {
+      "size" : "24x24",
+      "idiom" : "watch",
+      "scale" : "2x",
+      "role" : "notificationCenter",
+      "subtype" : "38mm"
+    },
+    {
+      "size" : "27.5x27.5",
+      "idiom" : "watch",
+      "scale" : "2x",
+      "role" : "notificationCenter",
+      "subtype" : "42mm"
+    },
+    {
+      "size" : "29x29",
+      "idiom" : "watch",
+      "role" : "companionSettings",
+      "scale" : "2x"
+    },
+    {
+      "size" : "29x29",
+      "idiom" : "watch",
+      "role" : "companionSettings",
+      "scale" : "3x"
+    },
+    {
+      "size" : "40x40",
+      "idiom" : "watch",
+      "scale" : "2x",
+      "role" : "appLauncher",
+      "subtype" : "38mm"
+    },
+    {
+      "size" : "86x86",
+      "idiom" : "watch",
+      "scale" : "2x",
+      "role" : "quickLook",
+      "subtype" : "38mm"
+    },
+    {
+      "size" : "98x98",
+      "idiom" : "watch",
+      "scale" : "2x",
+      "role" : "quickLook",
+      "subtype" : "42mm"
+    }
+  ],
+  "info" : {
+    "version" : 1,
+    "author" : "xcode"
+  }
+}

--- a/WatchExample/Base.lproj/Interface.storyboard
+++ b/WatchExample/Base.lproj/Interface.storyboard
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<document type="com.apple.InterfaceBuilder.WatchKit.Storyboard" version="3.0" toolsVersion="11134" systemVersion="15F34" targetRuntime="watchKit" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="AgC-eL-Hgc">
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="11106"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBWatchKitPlugin" version="11055"/>
+    </dependencies>
+    <scenes>
+        <!--Interface Controller-->
+        <scene sceneID="aou-V4-d1y">
+            <objects>
+                <controller id="AgC-eL-Hgc" customClass="InterfaceController" customModuleProvider="target"/>
+            </objects>
+            <point key="canvasLocation" x="220" y="345"/>
+        </scene>
+        <!--Static Notification Interface Controller-->
+        <scene sceneID="AEw-b0-oYE">
+            <objects>
+                <notificationController id="YCC-NB-fut">
+                    <items>
+                        <label alignment="left" text="Alert Label" id="IdU-wH-bcW"/>
+                    </items>
+                    <notificationCategory key="notificationCategory" identifier="myCategory" id="JfB-70-Muf"/>
+                    <connections>
+                        <outlet property="notificationAlertLabel" destination="IdU-wH-bcW" id="JKC-fr-R95"/>
+                        <segue destination="4sK-HA-Art" kind="relationship" relationship="dynamicNotificationInterface" id="kXh-Jw-8B1"/>
+                    </connections>
+                </notificationController>
+            </objects>
+            <point key="canvasLocation" x="220" y="643"/>
+        </scene>
+        <!--Notification Controller-->
+        <scene sceneID="ZPc-GJ-vnh">
+            <objects>
+                <controller id="4sK-HA-Art" customClass="NotificationController" customModuleProvider="target"/>
+            </objects>
+            <point key="canvasLocation" x="468" y="643"/>
+        </scene>
+    </scenes>
+</document>

--- a/WatchExample/Base.lproj/Interface.storyboard
+++ b/WatchExample/Base.lproj/Interface.storyboard
@@ -1,14 +1,14 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder.WatchKit.Storyboard" version="3.0" toolsVersion="11134" systemVersion="15F34" targetRuntime="watchKit" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="AgC-eL-Hgc">
+<document type="com.apple.InterfaceBuilder.WatchKit.Storyboard" version="3.0" toolsVersion="10117" systemVersion="15G31" targetRuntime="watchKit" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="AgC-eL-Hgc">
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="11106"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBWatchKitPlugin" version="11055"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="10085"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBWatchKitPlugin" version="10032"/>
     </dependencies>
     <scenes>
         <!--Interface Controller-->
         <scene sceneID="aou-V4-d1y">
             <objects>
-                <controller id="AgC-eL-Hgc" customClass="InterfaceController" customModuleProvider="target"/>
+                <controller id="AgC-eL-Hgc" customClass="InterfaceController" customModule="WatchExample" customModuleProvider="target"/>
             </objects>
             <point key="canvasLocation" x="220" y="345"/>
         </scene>
@@ -31,7 +31,7 @@
         <!--Notification Controller-->
         <scene sceneID="ZPc-GJ-vnh">
             <objects>
-                <controller id="4sK-HA-Art" customClass="NotificationController" customModuleProvider="target"/>
+                <controller id="4sK-HA-Art" customClass="NotificationController" customModule="WatchExample" customModuleProvider="target"/>
             </objects>
             <point key="canvasLocation" x="468" y="643"/>
         </scene>

--- a/WatchExample/Info.plist
+++ b/WatchExample/Info.plist
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleDisplayName</key>
+	<string>Directions (Swift)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>APPL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+	<key>UISupportedInterfaceOrientations</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationPortraitUpsideDown</string>
+	</array>
+	<key>WKCompanionAppBundleIdentifier</key>
+	<string>com.mapbox.MapboxDirectionsExample.swift</string>
+	<key>WKWatchKitApp</key>
+	<true/>
+</dict>
+</plist>


### PR DESCRIPTION
Also added a dummy watchOS target that embeds the watchOS framework to work around CocoaPods/CocoaPods#5687. We can remove the watchOS application and extension once CocoaPods/CocoaPods#5733 is released.

/cc @superpeteblaze @boundsj