### PR TITLE
Conform models to NSSecureCoding

### DIFF
--- a/MapboxDirections.xcodeproj/project.pbxproj
+++ b/MapboxDirections.xcodeproj/project.pbxproj
@@ -1439,7 +1439,6 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 7AB05E29E43D55326F7FA67B /* Pods-WatchExample.debug.xcconfig */;
 			buildSettings = {
-				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ANALYZER_NONNULL = YES;
 				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
@@ -1464,7 +1463,6 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 05045275F3647340E9698D26 /* Pods-WatchExample.release.xcconfig */;
 			buildSettings = {
-				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ANALYZER_NONNULL = YES;
 				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;

--- a/MapboxDirections.xcodeproj/project.pbxproj
+++ b/MapboxDirections.xcodeproj/project.pbxproj
@@ -79,6 +79,9 @@
 		DAC05F181CFC075300FA0071 /* MBRoute.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAC05F171CFC075300FA0071 /* MBRoute.swift */; };
 		DAC05F1A1CFC077C00FA0071 /* MBRouteLeg.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAC05F191CFC077C00FA0071 /* MBRouteLeg.swift */; };
 		DAC05F1C1CFC1E5300FA0071 /* v5_driving_dc_polyline.json in Resources */ = {isa = PBXBuildFile; fileRef = DAC05F1B1CFC1E5300FA0071 /* v5_driving_dc_polyline.json */; };
+		DAEF6CAD1D8BC017006A108F /* RouteStepTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAEF6CAC1D8BC017006A108F /* RouteStepTests.swift */; };
+		DAEF6CAE1D8BC017006A108F /* RouteStepTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAEF6CAC1D8BC017006A108F /* RouteStepTests.swift */; };
+		DAEF6CAF1D8BC017006A108F /* RouteStepTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAEF6CAC1D8BC017006A108F /* RouteStepTests.swift */; };
 		DD6254541AE70C1700017857 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD6254531AE70C1700017857 /* AppDelegate.swift */; };
 		DD6254561AE70C1700017857 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD6254551AE70C1700017857 /* ViewController.swift */; };
 		FB737DB2C6D8CC82A6FAA82C /* Pods_MapboxDirectionsTVTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = EBA232D519F6F671B2EDFCAF /* Pods_MapboxDirectionsTVTests.framework */; };
@@ -242,6 +245,7 @@
 		DAC05F171CFC075300FA0071 /* MBRoute.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MBRoute.swift; sourceTree = "<group>"; };
 		DAC05F191CFC077C00FA0071 /* MBRouteLeg.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MBRouteLeg.swift; sourceTree = "<group>"; };
 		DAC05F1B1CFC1E5300FA0071 /* v5_driving_dc_polyline.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = v5_driving_dc_polyline.json; sourceTree = "<group>"; };
+		DAEF6CAC1D8BC017006A108F /* RouteStepTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RouteStepTests.swift; sourceTree = SOURCE_ROOT; };
 		DD62544E1AE70C1700017857 /* Directions (Swift).app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "Directions (Swift).app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		DD6254521AE70C1700017857 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		DD6254531AE70C1700017857 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
@@ -414,6 +418,7 @@
 			isa = PBXGroup;
 			children = (
 				DA1A110A1D01045E009F82FA /* DirectionsTests.swift */,
+				DAEF6CAC1D8BC017006A108F /* RouteStepTests.swift */,
 				DA737EE71D0611CB005BDA16 /* V4Tests.swift */,
 				DA6C9DAB1CAEC72800094FBC /* V5Tests.swift */,
 				DA6C9DB11CAECA0E00094FBC /* Fixture.swift */,
@@ -1302,6 +1307,7 @@
 				DA737EE91D0611CB005BDA16 /* V4Tests.swift in Sources */,
 				DA1A10CE1D00F972009F82FA /* Fixture.swift in Sources */,
 				DA1A110C1D01045E009F82FA /* DirectionsTests.swift in Sources */,
+				DAEF6CAE1D8BC017006A108F /* RouteStepTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1326,6 +1332,7 @@
 				DA737EEA1D0611CB005BDA16 /* V4Tests.swift in Sources */,
 				DA1A10F51D010251009F82FA /* Fixture.swift in Sources */,
 				DA1A110D1D01045E009F82FA /* DirectionsTests.swift in Sources */,
+				DAEF6CAF1D8BC017006A108F /* RouteStepTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1363,6 +1370,7 @@
 				DA737EE81D0611CB005BDA16 /* V4Tests.swift in Sources */,
 				DA6C9DB21CAECA0E00094FBC /* Fixture.swift in Sources */,
 				DA1A110B1D01045E009F82FA /* DirectionsTests.swift in Sources */,
+				DAEF6CAD1D8BC017006A108F /* RouteStepTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/MapboxDirections/MBRoute.swift
+++ b/MapboxDirections/MBRoute.swift
@@ -50,12 +50,8 @@ public class Route: NSObject, NSSecureCoding {
     }
     
     public required init?(coder decoder: NSCoder) {
-        let coordinateValues = decoder.decodeObjectForKey("coordinates") as? [NSValue]
-        coordinates = coordinateValues?.map({ (value) -> CLLocationCoordinate2D in
-            var coordinate: CLLocationCoordinate2D = kCLLocationCoordinate2DInvalid
-            value.getValue(&coordinate)
-            return coordinate
-        })
+        let coordinateDictionaries = decoder.decodeObjectForKey("coordinates") as? [[String: CLLocationDegrees]]
+        coordinates = coordinateDictionaries?.map { CLLocationCoordinate2D(latitude: $0["latitude"]!, longitude: $0["longitude"]!) }
         
         legs = decoder.decodeObjectForKey("legs") as? [RouteLeg] ?? []
         distance = decoder.decodeDoubleForKey("distance")
@@ -68,11 +64,11 @@ public class Route: NSObject, NSSecureCoding {
     }
     
     public func encodeWithCoder(coder: NSCoder) {
-        let coordinateValues = coordinates?.map { (coordinate) -> NSValue in
-            var coordinate = coordinate
-            return NSValue(bytes: &coordinate, objCType: "{dd}")
-        }
-        coder.encodeObject(coordinateValues, forKey: "coordinates")
+        let coordinateDictionaries = coordinates?.map { [
+            "latitude": $0.latitude,
+            "longitude": $0.longitude,
+        ] }
+        coder.encodeObject(coordinateDictionaries, forKey: "coordinates")
         
         coder.encodeObject(legs, forKey: "legs")
         coder.encodeDouble(distance, forKey: "distance")

--- a/MapboxDirections/MBRouteLeg.swift
+++ b/MapboxDirections/MBRouteLeg.swift
@@ -6,7 +6,7 @@ import Polyline
  You do not create instances of this class directly. Instead, you receive route leg objects as part of route objects when you request directions using the `Directions.calculateDirections(options:completionHandler:)` method.
  */
 @objc(MBRouteLeg)
-public class RouteLeg: NSObject {
+public class RouteLeg: NSObject, NSSecureCoding {
     // MARK: Getting the Leg Geometry
     
     /**
@@ -83,6 +83,30 @@ public class RouteLeg: NSObject {
     internal convenience init(json: JSONDictionary, source: Waypoint, destination: Waypoint, profileIdentifier: String) {
         let steps = (json["steps"] as? [JSONDictionary] ?? []).map { RouteStep(json: $0) }
         self.init(steps: steps, json: json, source: source, destination: destination, profileIdentifier: profileIdentifier)
+    }
+    
+    public required init?(coder decoder: NSCoder) {
+        source = decoder.decodeObjectForKey("source") as! Waypoint
+        destination = decoder.decodeObjectForKey("destination") as! Waypoint
+        steps = decoder.decodeObjectForKey("steps") as? [RouteStep] ?? []
+        name = decoder.decodeObjectForKey("name") as! String
+        distance = decoder.decodeDoubleForKey("distance")
+        expectedTravelTime = decoder.decodeDoubleForKey("expectedTravelTime")
+        profileIdentifier = decoder.decodeObjectForKey("profileIdentifier") as! String
+    }
+    
+    public static func supportsSecureCoding() -> Bool {
+        return true
+    }
+    
+    public func encodeWithCoder(coder: NSCoder) {
+        coder.encodeObject(source, forKey: "source")
+        coder.encodeObject(destination, forKey: "destination")
+        coder.encodeObject(steps, forKey: "steps")
+        coder.encodeObject(name, forKey: "name")
+        coder.encodeDouble(distance, forKey: "distance")
+        coder.encodeDouble(expectedTravelTime, forKey: "expectedTravelTime")
+        coder.encodeObject(profileIdentifier, forKey: "profileIdentifier")
     }
 }
 

--- a/RouteStepTests.swift
+++ b/RouteStepTests.swift
@@ -1,0 +1,44 @@
+import XCTest
+@testable import MapboxDirections
+
+class RouteStepTests: XCTestCase {
+    func testCoding() {
+        let coordinates = [
+            CLLocationCoordinate2D(latitude: -122.220694, longitude: 37.853913),
+            CLLocationCoordinate2D(latitude: -122.22044, longitude: 37.854032),
+            CLLocationCoordinate2D(latitude: -122.220168, longitude: 37.854149),
+        ]
+        let json = [
+            "mode": "driving",
+            "maneuver": [
+                "instruction": "Keep left at the fork onto CA 24",
+                "bearing_before": 55,
+            ],
+            "distance": 1669.7,
+            "duration": 75.6,
+        ]
+        
+        let step = RouteStep(finalHeading: 59, maneuverType: .ReachFork, maneuverDirection: .Left, maneuverLocation: CLLocationCoordinate2D(latitude: 37.853913, longitude: -122.220694), name: nil, coordinates: coordinates, json: json)
+        
+        let data = NSKeyedArchiver.archivedDataWithRootObject(step)
+        let unarchivedStep = NSKeyedUnarchiver.unarchiveObjectWithData(data) as! RouteStep
+        XCTAssertNotNil(unarchivedStep)
+        
+        XCTAssertEqual(unarchivedStep.coordinates?.count, step.coordinates?.count)
+        XCTAssertEqual(unarchivedStep.coordinates?.first?.latitude, step.coordinates?.first?.latitude)
+        XCTAssertEqual(unarchivedStep.coordinates?.first?.longitude, step.coordinates?.first?.longitude)
+        XCTAssertEqual(unarchivedStep.instructions, step.instructions)
+        XCTAssertEqual(unarchivedStep.initialHeading, step.initialHeading)
+        XCTAssertEqual(unarchivedStep.finalHeading, step.finalHeading)
+        XCTAssertEqual(unarchivedStep.maneuverType, step.maneuverType)
+        XCTAssertEqual(unarchivedStep.maneuverDirection, step.maneuverDirection)
+        XCTAssertEqual(unarchivedStep.maneuverLocation.latitude, step.maneuverLocation.latitude)
+        XCTAssertEqual(unarchivedStep.maneuverLocation.longitude, step.maneuverLocation.longitude)
+        XCTAssertEqual(unarchivedStep.exitIndex, step.exitIndex)
+        XCTAssertEqual(unarchivedStep.distance, step.distance)
+        XCTAssertEqual(unarchivedStep.expectedTravelTime, step.expectedTravelTime)
+        XCTAssertEqual(unarchivedStep.name, step.name)
+        XCTAssertEqual(unarchivedStep.transportType, step.transportType)
+        XCTAssertEqual(unarchivedStep.destinations, step.destinations)
+    }
+}


### PR DESCRIPTION
This change makes the rest of the model classes – Route, RouteLeg, and RouteStep – conform to NSSecureCoding, so that the application can simply archive an instance of one of these classes using NSKeyedArchiver for state restoration or some other purpose.

/cc @bsudekum @incanus