### PR TITLE
Avoid deserializing non-JSON response data

### DIFF
--- a/MapboxDirections/MBDirections.swift
+++ b/MapboxDirections/MBDirections.swift
@@ -188,7 +188,7 @@ public class Directions: NSObject {
         request.setValue(userAgent, forHTTPHeaderField: "User-Agent")
         return NSURLSession.sharedSession().dataTaskWithRequest(request) { (data, response, error) in
             var json: JSONDictionary = [:]
-            if let data = data {
+            if let data = data where response?.MIMEType == "application/json" {
                 do {
                     json = try NSJSONSerialization.JSONObjectWithData(data, options: []) as! JSONDictionary
                 } catch {


### PR DESCRIPTION
Fixed an assertion failure that could occur (instead of an error being passed to the completion handler) if the response data was not the expected JSON format. This can happen, for instance, on a captive network.

Normally, one might also consider checking the response’s status code at this point. However, we actually do need to parse the JSON response for certain error codes like 404. So that error handling happens in the subsequent call to `Directions.descriptiveError(_:response:underlyingError:)`.

/cc @bsudekum @willwhite