### PR TITLE
Serialize none indication as empty indication

### DIFF
--- a/MapboxDirections/MBLaneIndication.swift
+++ b/MapboxDirections/MBLaneIndication.swift
@@ -26,6 +26,8 @@ extension LaneIndication: CustomStringConvertible {
                 scope.insert(.Left)
             case "uturn":
                 scope.insert(.UTurn)
+            case "none":
+                break
             default:
                 return nil
             }


### PR DESCRIPTION
When the `indication` field coming from the API is `none`, convert that to an empty `LaneIndication` value instead of `nil`.

/cc @bsudekum