### PR TITLE
Round-trip right and none lane indications

### DIFF
--- a/MapboxDirections/MBLaneIndication.swift
+++ b/MapboxDirections/MBLaneIndication.swift
@@ -36,6 +36,10 @@ extension LaneIndication: CustomStringConvertible {
     }
     
     public var description: String {
+        if isEmpty {
+            return "none"
+        }
+        
         var descriptions: [String] = []
         if contains(LaneIndication.SharpRight) {
             descriptions.append("sharp right")

--- a/MapboxDirections/MBLaneIndication.swift
+++ b/MapboxDirections/MBLaneIndication.swift
@@ -20,10 +20,10 @@ extension LaneIndication: CustomStringConvertible {
                 scope.insert(.StraightAhead)
             case "slight left":
                 scope.insert(.SlightLeft)
-            case "sharp left":
-                scope.insert(.SharpLeft)
             case "left":
                 scope.insert(.Left)
+            case "sharp left":
+                scope.insert(.SharpLeft)
             case "uturn":
                 scope.insert(.UTurn)
             case "none":
@@ -40,8 +40,8 @@ extension LaneIndication: CustomStringConvertible {
         if contains(LaneIndication.SharpRight) {
             descriptions.append("sharp right")
         }
-        if contains(LaneIndication.SharpRight) {
-            descriptions.append("sharp right")
+        if contains(LaneIndication.Right) {
+            descriptions.append("right")
         }
         if contains(LaneIndication.SlightRight) {
             descriptions.append("slight right")


### PR DESCRIPTION
Fixed round-tripping of `right` and `none` lane indications back to the JSON string value.

/cc @bsudekum @freenerd