### PR TITLE
Mapbox iOS SDK v3.5.0, OHHTTPStubs master

### DIFF
--- a/Cartfile.private
+++ b/Cartfile.private
@@ -1,2 +1,2 @@
 binary "https://www.mapbox.com/ios-sdk/Mapbox-iOS-SDK.json" ~> 3.4
-github "AliSoftware/OHHTTPStubs" "swift-3.0"
+github "AliSoftware/OHHTTPStubs" "master"

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,3 +1,3 @@
-binary "https://www.mapbox.com/ios-sdk/Mapbox-iOS-SDK.json" "3.4.2"
-github "AliSoftware/OHHTTPStubs" "57feceaabf333e72b2c637dfba6c13a7a5c49619"
+binary "https://www.mapbox.com/ios-sdk/Mapbox-iOS-SDK.json" "3.5.0"
+github "AliSoftware/OHHTTPStubs" "8660a5a2253bdd6291be36251ba90b06bceb46a2"
 github "raphaelmor/Polyline" "v4.1.1"


### PR DESCRIPTION
Moved off OHHTTPStubs’ swift-3.0 branch, which is [going away soon](https://github.com/AliSoftware/OHHTTPStubs/pull/240#issuecomment-290409247), now that the master branch is finally on Swift 3.

/cc @bsudekum