### PR TITLE
Make RouteOptions available on route response

### DIFF
--- a/MapboxDirections/MBRoute.swift
+++ b/MapboxDirections/MBRoute.swift
@@ -156,9 +156,7 @@ open class Route: NSObject, NSSecureCoding {
     open let expectedTravelTime: TimeInterval
     
     /**
-     A string specifying the primary mode of transportation for the route.
-     
-     The value of this property is `MBDirectionsProfileIdentifierAutomobile`, `MBDirectionsProfileIdentifierAutomobileAvoidingTraffic`, `MBDirectionsProfileIdentifierCycling`, or `MBDirectionsProfileIdentifierWalking`, depending on the `profileIdentifier` property of the original `RouteOptions` object. This property reflects the primary mode of transportation used for the route. Individual steps along the route might use different modes of transportation as necessary.
+     `RouteOptions` used to create the directions request.
      */
     open let routeOptions: RouteOptions
 }

--- a/MapboxDirections/MBRoute.swift
+++ b/MapboxDirections/MBRoute.swift
@@ -24,7 +24,7 @@ open class Route: NSObject, NSSecureCoding {
      
      - parameter json: A JSON dictionary representation of the route as returned by the Mapbox Directions API.
      - parameter waypoints: An array of waypoints that the route visits in chronological order.
-     - parameter profileIdentifier: The profile identifier used to request the routes.
+     - parameter routeOptions: The `RouteOptions` used to create the request.
      */
     public convenience init(json: [String: Any], waypoints: [Waypoint], routeOptions: RouteOptions) {
         // Associate each leg JSON with a source and destination. The sequence of destinations is offset by one from the sequence of sources.
@@ -157,6 +157,8 @@ open class Route: NSObject, NSSecureCoding {
     
     /**
      `RouteOptions` used to create the directions request.
+     
+     The route options object’s profileIdentifier property reflects the primary mode of transportation used for the route. Individual steps along the route might use different modes of transportation as necessary.
      */
     open let routeOptions: RouteOptions
 }

--- a/MapboxDirections/MBRoute.swift
+++ b/MapboxDirections/MBRoute.swift
@@ -9,8 +9,8 @@ import Polyline
 open class Route: NSObject, NSSecureCoding {
     // MARK: Creating a Route
     
-    internal init(profileIdentifier: MBDirectionsProfileIdentifier, legs: [RouteLeg], distance: CLLocationDistance, expectedTravelTime: TimeInterval, coordinates: [CLLocationCoordinate2D]?) {
-        self.profileIdentifier = profileIdentifier
+    internal init(routeOptions: RouteOptions, legs: [RouteLeg], distance: CLLocationDistance, expectedTravelTime: TimeInterval, coordinates: [CLLocationCoordinate2D]?) {
+        self.routeOptions = routeOptions
         self.legs = legs
         self.distance = distance
         self.expectedTravelTime = expectedTravelTime
@@ -26,12 +26,12 @@ open class Route: NSObject, NSSecureCoding {
      - parameter waypoints: An array of waypoints that the route visits in chronological order.
      - parameter profileIdentifier: The profile identifier used to request the routes.
      */
-    public convenience init(json: [String: Any], waypoints: [Waypoint], profileIdentifier: MBDirectionsProfileIdentifier) {
+    public convenience init(json: [String: Any], waypoints: [Waypoint], routeOptions: RouteOptions) {
         // Associate each leg JSON with a source and destination. The sequence of destinations is offset by one from the sequence of sources.
         let legInfo = zip(zip(waypoints.prefix(upTo: waypoints.endIndex - 1), waypoints.suffix(from: 1)),
                           json["legs"] as? [JSONDictionary] ?? [])
         let legs = legInfo.map { (endpoints, json) -> RouteLeg in
-            RouteLeg(json: json, source: endpoints.0, destination: endpoints.1, profileIdentifier: profileIdentifier)
+            RouteLeg(json: json, source: endpoints.0, destination: endpoints.1, profileIdentifier: routeOptions.profileIdentifier)
         }
         let distance = json["distance"] as! Double
         let expectedTravelTime = json["duration"] as! Double
@@ -46,7 +46,7 @@ open class Route: NSObject, NSSecureCoding {
             coordinates = nil
         }
         
-        self.init(profileIdentifier: profileIdentifier, legs: legs, distance: distance, expectedTravelTime: expectedTravelTime, coordinates: coordinates)
+        self.init(routeOptions: routeOptions, legs: legs, distance: distance, expectedTravelTime: expectedTravelTime, coordinates: coordinates)
     }
     
     public required init?(coder decoder: NSCoder) {
@@ -64,10 +64,10 @@ open class Route: NSObject, NSSecureCoding {
         distance = decoder.decodeDouble(forKey: "distance")
         expectedTravelTime = decoder.decodeDouble(forKey: "expectedTravelTime")
         
-        guard let decodedProfileIdentifier = decoder.decodeObject(of: NSString.self, forKey: "profileIdentifier") as String? else {
+        guard let options = decoder.decodeObject(of: [RouteOptions.self], forKey: "routeOptions") as? RouteOptions else {
             return nil
         }
-        profileIdentifier = MBDirectionsProfileIdentifier(rawValue: decodedProfileIdentifier)
+        routeOptions = options
     }
     
     open static var supportsSecureCoding = true
@@ -82,7 +82,7 @@ open class Route: NSObject, NSSecureCoding {
         coder.encode(legs, forKey: "legs")
         coder.encode(distance, forKey: "distance")
         coder.encode(expectedTravelTime, forKey: "expectedTravelTime")
-        coder.encode(profileIdentifier, forKey: "profileIdentifier")
+        coder.encode(routeOptions, forKey: "routeOptions")
     }
     
     // MARK: Getting the Route Geometry
@@ -160,14 +160,14 @@ open class Route: NSObject, NSSecureCoding {
      
      The value of this property is `MBDirectionsProfileIdentifierAutomobile`, `MBDirectionsProfileIdentifierAutomobileAvoidingTraffic`, `MBDirectionsProfileIdentifierCycling`, or `MBDirectionsProfileIdentifierWalking`, depending on the `profileIdentifier` property of the original `RouteOptions` object. This property reflects the primary mode of transportation used for the route. Individual steps along the route might use different modes of transportation as necessary.
      */
-    open let profileIdentifier: MBDirectionsProfileIdentifier
+    open let routeOptions: RouteOptions
 }
 
 // MARK: Support for Directions API v4
 
 internal class RouteV4: Route {
-    convenience init(json: JSONDictionary, waypoints: [Waypoint], profileIdentifier: MBDirectionsProfileIdentifier) {
-        let leg = RouteLegV4(json: json, source: waypoints.first!, destination: waypoints.last!, profileIdentifier: profileIdentifier)
+    convenience init(json: JSONDictionary, waypoints: [Waypoint], routeOptions: RouteOptions) {
+        let leg = RouteLegV4(json: json, source: waypoints.first!, destination: waypoints.last!, profileIdentifier: routeOptions.profileIdentifier)
         let distance = json["distance"] as! Double
         let expectedTravelTime = json["duration"] as! Double
         
@@ -181,6 +181,6 @@ internal class RouteV4: Route {
             coordinates = nil
         }
         
-        self.init(profileIdentifier: profileIdentifier, legs: [leg], distance: distance, expectedTravelTime: expectedTravelTime, coordinates: coordinates)
+        self.init(routeOptions: routeOptions, legs: [leg], distance: distance, expectedTravelTime: expectedTravelTime, coordinates: coordinates)
     }
 }

--- a/MapboxDirections/MBRouteOptions.swift
+++ b/MapboxDirections/MBRouteOptions.swift
@@ -285,7 +285,7 @@ open class RouteOptions: NSObject {
             return Waypoint(coordinate: coordinate, name: waypoint["name"] as? String)
         }
         let routes = (json["routes"] as? [JSONDictionary])?.map {
-            Route(json: $0, waypoints: waypoints ?? self.waypoints, profileIdentifier: profileIdentifier)
+            Route(json: $0, waypoints: waypoints ?? self.waypoints, routeOptions: self)
         }
         return (waypoints, routes)
     }
@@ -380,7 +380,7 @@ open class RouteOptionsV4: RouteOptions {
         let intermediateWaypoints = (json["waypoints"] as! [JSONDictionary]).flatMap { Waypoint(geoJSON: $0) }
         let waypoints = [sourceWaypoint] + intermediateWaypoints + [destinationWaypoint]
         let routes = (json["routes"] as? [JSONDictionary])?.map {
-            RouteV4(json: $0, waypoints: waypoints, profileIdentifier: profileIdentifier)
+            RouteV4(json: $0, waypoints: waypoints, routeOptions: self)
         }
         return (waypoints, routes)
     }

--- a/MapboxDirectionsTests/V5Tests.swift
+++ b/MapboxDirectionsTests/V5Tests.swift
@@ -52,6 +52,13 @@ class V5Tests: XCTestCase {
             XCTAssertEqual(task.state, .completed)
         }
         
+        let opts = route!.routeOptions
+        
+        XCTAssertEqual(opts.profileIdentifier, .automobile)
+        XCTAssertTrue(opts.includesSteps)
+        XCTAssertTrue(opts.includesAlternativeRoutes)
+        XCTAssertEqual(opts.routeShapeResolution, .full)
+        
         XCTAssertNotNil(route)
         XCTAssertNotNil(route!.coordinates)
         XCTAssertEqual(route!.coordinates!.count, 28_442)

--- a/MapboxDirectionsTests/V5Tests.swift
+++ b/MapboxDirectionsTests/V5Tests.swift
@@ -52,13 +52,6 @@ class V5Tests: XCTestCase {
             XCTAssertEqual(task.state, .completed)
         }
         
-        let opts = route!.routeOptions
-        
-        XCTAssertEqual(opts.profileIdentifier, .automobile)
-        XCTAssertTrue(opts.includesSteps)
-        XCTAssertTrue(opts.includesAlternativeRoutes)
-        XCTAssertEqual(opts.routeShapeResolution, .full)
-        
         XCTAssertNotNil(route)
         XCTAssertNotNil(route!.coordinates)
         XCTAssertEqual(route!.coordinates!.count, 28_442)
@@ -68,6 +61,10 @@ class V5Tests: XCTestCase {
         XCTAssertEqual(round(route!.coordinates!.first!.latitude), 38)
         XCTAssertEqual(round(route!.coordinates!.first!.longitude), -122)
         XCTAssertEqual(route!.legs.count, 1)
+        
+        let opts = route!.routeOptions
+        
+        XCTAssertEqual(opts, options)
         
         let leg = route!.legs.first!
         XCTAssertEqual(leg.name, "I 80, I 80;US 30")


### PR DESCRIPTION
Instead of returning the profile identifier on the route, this replaces it with the entire RouteOptions used to create the directions request.

/cc @frederoni @1ec5 