### PR TITLE
Inline HTTPURLResponse extension constants

### DIFF
--- a/MapboxDirections/MBDirections.swift
+++ b/MapboxDirections/MBDirections.swift
@@ -278,27 +278,22 @@ open class Directions: NSObject {
 }
 
 extension HTTPURLResponse {
-    
-    @nonobjc static let rateLimitIntervalHeaderKey = "X-Rate-Limit-Interval"
-    @nonobjc static let rateLimitLimitHeaderKey = "X-Rate-Limit-Limit"
-    @nonobjc static let rateLimitResetHeaderKey = "X-Rate-Limit-Reset"
-    
     var rateLimit: UInt? {
-        guard let limit = allHeaderFields[HTTPURLResponse.rateLimitLimitHeaderKey] as? String else {
+        guard let limit = allHeaderFields["X-Rate-Limit-Limit"] as? String else {
             return nil
         }
         return UInt(limit)
     }
     
     var rateLimitInterval: TimeInterval? {
-        guard let interval = allHeaderFields[HTTPURLResponse.rateLimitIntervalHeaderKey] as? String else {
+        guard let interval = allHeaderFields["X-Rate-Limit-Interval"] as? String else {
             return nil
         }
         return TimeInterval(interval)
     }
     
     var rateLimitResetTime: Date? {
-        guard let resetTime = allHeaderFields[HTTPURLResponse.rateLimitResetHeaderKey] as? String else {
+        guard let resetTime = allHeaderFields["X-Rate-Limit-Reset"] as? String else {
             return nil
         }
         guard let resetTimeNumber = Double(resetTime) else {


### PR DESCRIPTION
Inlined HTTPURLResponse extension constants, which were only being used in one place each and would be unlikely to change. This change doesn’t address a build issue, but it does make the library more consistent with mapbox/MapboxGeocoder.swift#105 and mapbox/MapboxStatic.swift#60. The order in which these constants were declared also differed from the order in which they were used, which was confusing.

/cc @frederoni