### PR TITLE
Adopt NSSecureCoding in RouteOptions

### DIFF
--- a/MapboxDirections.xcodeproj/project.pbxproj
+++ b/MapboxDirections.xcodeproj/project.pbxproj
@@ -109,6 +109,9 @@
 		DADD27F31E5ABD4300D31FAD /* Mapbox.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DADD27F21E5ABD4300D31FAD /* Mapbox.framework */; };
 		DADD27F41E5ABD6000D31FAD /* Mapbox.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DADD27F21E5ABD4300D31FAD /* Mapbox.framework */; };
 		DADD27F71E5AC8E900D31FAD /* MapboxDirections.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DA6C9D881CAE442B00094FBC /* MapboxDirections.framework */; };
+		DAE9E0F41EB7DE2E001E8E8B /* RouteOptionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAE9E0F31EB7DE2E001E8E8B /* RouteOptionsTests.swift */; };
+		DAE9E0F51EB7DE2E001E8E8B /* RouteOptionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAE9E0F31EB7DE2E001E8E8B /* RouteOptionsTests.swift */; };
+		DAE9E0F61EB7DE2E001E8E8B /* RouteOptionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAE9E0F31EB7DE2E001E8E8B /* RouteOptionsTests.swift */; };
 		F448F8311DDCC65C000BC343 /* Polyline.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F448F82A1DDCC5B6000BC343 /* Polyline.framework */; };
 		F448F8341DDCC6C1000BC343 /* Polyline.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F448F82A1DDCC5B6000BC343 /* Polyline.framework */; };
 		F448F83D1DDCC6FA000BC343 /* Polyline.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F448F83A1DDCC6EB000BC343 /* Polyline.framework */; };
@@ -201,6 +204,7 @@
 		DADD27EC1E5AB0EB00D31FAD /* ViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ViewController.h; sourceTree = "<group>"; };
 		DADD27ED1E5AB0EB00D31FAD /* ViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ViewController.m; sourceTree = "<group>"; };
 		DADD27F21E5ABD4300D31FAD /* Mapbox.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Mapbox.framework; path = Carthage/Build/iOS/Mapbox.framework; sourceTree = "<group>"; };
+		DAE9E0F31EB7DE2E001E8E8B /* RouteOptionsTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RouteOptionsTests.swift; sourceTree = SOURCE_ROOT; };
 		DD6254731AE70CB700017857 /* MBDirections.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MBDirections.swift; sourceTree = "<group>"; };
 		F448F82A1DDCC5B6000BC343 /* Polyline.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Polyline.framework; path = Carthage/Build/iOS/Polyline.framework; sourceTree = "<group>"; };
 		F448F8381DDCC6D7000BC343 /* OHHTTPStubs.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = OHHTTPStubs.framework; path = Carthage/Build/iOS/OHHTTPStubs.framework; sourceTree = "<group>"; };
@@ -336,6 +340,7 @@
 			isa = PBXGroup;
 			children = (
 				F4D785EE1DDD82C100FF4665 /* RouteStepTests.swift */,
+				DAE9E0F31EB7DE2E001E8E8B /* RouteOptionsTests.swift */,
 				DA1A110A1D01045E009F82FA /* DirectionsTests.swift */,
 				DA737EE71D0611CB005BDA16 /* V4Tests.swift */,
 				DA6C9DAB1CAEC72800094FBC /* V5Tests.swift */,
@@ -903,6 +908,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				DAE9E0F51EB7DE2E001E8E8B /* RouteOptionsTests.swift in Sources */,
 				C53A02291E92C27A009837BD /* AnnotationTests.swift in Sources */,
 				DA1A10CD1D00F972009F82FA /* V5Tests.swift in Sources */,
 				DA737EE91D0611CB005BDA16 /* V4Tests.swift in Sources */,
@@ -934,6 +940,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				DAE9E0F61EB7DE2E001E8E8B /* RouteOptionsTests.swift in Sources */,
 				C53A022A1E92C27B009837BD /* AnnotationTests.swift in Sources */,
 				DA1A10F41D010251009F82FA /* V5Tests.swift in Sources */,
 				DA737EEA1D0611CB005BDA16 /* V4Tests.swift in Sources */,
@@ -983,6 +990,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				DAE9E0F41EB7DE2E001E8E8B /* RouteOptionsTests.swift in Sources */,
 				C5247D711E818A24004B6154 /* AnnotationTests.swift in Sources */,
 				DA6C9DAC1CAEC72800094FBC /* V5Tests.swift in Sources */,
 				DA737EE81D0611CB005BDA16 /* V4Tests.swift in Sources */,

--- a/MapboxDirections/MBAttribute.swift
+++ b/MapboxDirections/MBAttribute.swift
@@ -6,21 +6,25 @@ extension AttributeOptions: CustomStringConvertible {
     /**
      Creates an AttributeOptions from the given description strings.
      */
-    public init?(description: String) {
-        var scope: AttributeOptions = []
-        switch description {
-        case "distance":
-            scope.update(with: .distance)
-        case "expectedTravelTime":
-            scope.update(with: .expectedTravelTime)
-        case "openStreetMapNodeIdentifier":
-            scope.update(with: .openStreetMapNodeIdentifier)
-        case "speed":
-            scope.update(with: .speed)
-        default:
-            return nil
+    public init?(descriptions: [String]) {
+        var attributeOptions: AttributeOptions = []
+        for description in descriptions {
+            switch description {
+            case "distance":
+                attributeOptions.update(with: .distance)
+            case "expectedTravelTime":
+                attributeOptions.update(with: .expectedTravelTime)
+            case "openStreetMapNodeIdentifier":
+                attributeOptions.update(with: .openStreetMapNodeIdentifier)
+            case "speed":
+                attributeOptions.update(with: .speed)
+            case "":
+                continue
+            default:
+                return nil
+            }
         }
-        self.init(rawValue: scope.rawValue)
+        self.init(rawValue: attributeOptions.rawValue)
     }
     
     public var description: String {

--- a/MapboxDirections/MBLaneIndication.swift
+++ b/MapboxDirections/MBLaneIndication.swift
@@ -7,32 +7,32 @@ extension LaneIndication: CustomStringConvertible {
      Creates a lane indication from the given description strings.
      */
     public init?(descriptions: [String]) {
-        var scope: LaneIndication = []
+        var laneIndication: LaneIndication = []
         for description in descriptions {
             switch description {
             case "sharp right":
-                scope.insert(.sharpRight)
+                laneIndication.insert(.sharpRight)
             case "right":
-                scope.insert(.right)
+                laneIndication.insert(.right)
             case "slight right":
-                scope.insert(.slightRight)
+                laneIndication.insert(.slightRight)
             case "straight":
-                scope.insert(.straightAhead)
+                laneIndication.insert(.straightAhead)
             case "slight left":
-                scope.insert(.slightLeft)
+                laneIndication.insert(.slightLeft)
             case "left":
-                scope.insert(.left)
+                laneIndication.insert(.left)
             case "sharp left":
-                scope.insert(.sharpLeft)
+                laneIndication.insert(.sharpLeft)
             case "uturn":
-                scope.insert(.uTurn)
+                laneIndication.insert(.uTurn)
             case "none":
                 break
             default:
                 return nil
             }
         }
-        self.init(rawValue: scope.rawValue)
+        self.init(rawValue: laneIndication.rawValue)
     }
     
     public var description: String {

--- a/RouteOptionsTests.swift
+++ b/RouteOptionsTests.swift
@@ -1,0 +1,38 @@
+import XCTest
+@testable import MapboxDirections
+
+class RouteOptionsTests: XCTestCase {
+    func testCoding() {
+        let coordinates = [
+            CLLocationCoordinate2D(latitude: 52.5109, longitude: 13.4301),
+            CLLocationCoordinate2D(latitude: 52.5080, longitude: 13.4265),
+            CLLocationCoordinate2D(latitude: 52.5021, longitude: 13.4316),
+        ]
+        
+        let options = RouteOptions(coordinates: coordinates, profileIdentifier: .automobileAvoidingTraffic)
+        
+        let encodedData = NSMutableData()
+        let keyedArchiver = NSKeyedArchiver(forWritingWith: encodedData)
+        keyedArchiver.requiresSecureCoding = true
+        keyedArchiver.encode(options, forKey: "options")
+        keyedArchiver.finishEncoding()
+        
+        let keyedUnarchiver = NSKeyedUnarchiver(forReadingWith: encodedData as Data)
+        keyedUnarchiver.requiresSecureCoding = true
+        let unarchivedOptions = keyedUnarchiver.decodeObject(of: RouteOptions.self, forKey: "options")!
+        keyedUnarchiver.finishDecoding()
+        
+        XCTAssertNotNil(unarchivedOptions)
+        
+        let unarchivedWaypoints = unarchivedOptions.waypoints
+        XCTAssertEqual(unarchivedWaypoints.count, coordinates.count)
+        XCTAssertEqual(unarchivedWaypoints[0].coordinate.latitude, coordinates[0].latitude)
+        XCTAssertEqual(unarchivedWaypoints[0].coordinate.longitude, coordinates[0].longitude)
+        XCTAssertEqual(unarchivedWaypoints[1].coordinate.latitude, coordinates[1].latitude)
+        XCTAssertEqual(unarchivedWaypoints[1].coordinate.longitude, coordinates[1].longitude)
+        XCTAssertEqual(unarchivedWaypoints[2].coordinate.latitude, coordinates[2].latitude)
+        XCTAssertEqual(unarchivedWaypoints[2].coordinate.longitude, coordinates[2].longitude)
+        
+        XCTAssertEqual(unarchivedOptions.profileIdentifier, options.profileIdentifier)
+    }
+}


### PR DESCRIPTION
Implemented NSSecureCoding conformance in RouteOptions and added tests of that conformance.

Fixes #127. Depends on #128.

/cc @bsudekum @frederoni