### PR TITLE
Refer to traffic availability document

### DIFF
--- a/MapboxDirections/MBRouteOptions.h
+++ b/MapboxDirections/MBRouteOptions.h
@@ -19,7 +19,7 @@ extern MBDirectionsProfileIdentifier const MBDirectionsProfileIdentifierAutomobi
  
  This profile avoids traffic congestion based on current traffic data. A driving route may use a ferry where necessary.
  
- Where traffic data is absent, this profile prefers high-speed roads like highways, similar to `MBDirectionsProfileIdentifierAutomobile`.
+ Traffic data is available in [a number of countries and territories worldwide](https://www.mapbox.com/api-documentation/pages/traffic-countries.html). Where traffic data is unavailable, this profile prefers high-speed roads like highways, similar to `MBDirectionsProfileIdentifierAutomobile`.
  */
 extern MBDirectionsProfileIdentifier const MBDirectionsProfileIdentifierAutomobileAvoidingTraffic;
 


### PR DESCRIPTION
Added a link to a document listing the countries and territories for which the traffic-optimized routing profile is available.

/cc @bsudekum