### PR TITLE
Fix for missing maneuver direction

### DIFF
--- a/MapboxDirections/MBRouteStep.swift
+++ b/MapboxDirections/MBRouteStep.swift
@@ -557,10 +557,11 @@ open class RouteStep: NSObject, NSSecureCoding {
             return nil
         }
         maneuverType = ManeuverType(description: maneuverTypeDescription)
-        guard let maneuverDirectionDescription = decoder.decodeObject(of: NSString.self, forKey: "maneuverDirection") as String? else {
-            return nil
+        if let maneuverDirectionDescription = decoder.decodeObject(of: NSString.self, forKey: "maneuverDirection") as String? {
+            maneuverDirection = ManeuverDirection(description: maneuverDirectionDescription)
+        } else {
+            maneuverDirection = nil
         }
-        maneuverDirection = ManeuverDirection(description: maneuverDirectionDescription)
         
         if let maneuverLocationDictionary = decoder.decodeObject(of: [NSDictionary.self, NSString.self, NSNumber.self], forKey: "maneuverLocation") as? [String: CLLocationDegrees],
             let latitude = maneuverLocationDictionary["latitude"],


### PR DESCRIPTION
`maneuverDirection` is missing from a few `RouteStep`s and in those cases, we returned nil instead of decoding the remaining data.

~~We have to set a value when decoding but I don't know if it's correct to assume that a missing maneuverDirection means straightAhead or not.~~

@1ec5 @bsudekum @freenerd 👀 