### PR TITLE
Label first argument of more methods

### DIFF
--- a/Directions Example/ViewController.m
+++ b/Directions Example/ViewController.m
@@ -36,7 +36,7 @@ NSString * const MapboxAccessToken = @"<# your Mapbox access token #>";
     MBRouteOptions *options = [[MBRouteOptions alloc] initWithWaypoints:waypoints profileIdentifier:nil];
     options.includesSteps = YES;
     
-    [[[MBDirections alloc] initWithAccessToken:MapboxAccessToken] calculateDirectionsWithOptions:options completionHandler:^(NSArray<MBWaypoint *> * _Nullable waypoints, NSArray<MBRoute *> * _Nullable routes, NSError * _Nullable error) {
+    (void)[[[MBDirections alloc] initWithAccessToken:MapboxAccessToken] calculateDirectionsWithOptions:options completionHandler:^(NSArray<MBWaypoint *> * _Nullable waypoints, NSArray<MBRoute *> * _Nullable routes, NSError * _Nullable error) {
         if (error) {
             NSLog(@"Error calculating directions: %@", error);
             return;

--- a/MapboxDirections/MBRoute.swift
+++ b/MapboxDirections/MBRoute.swift
@@ -3,7 +3,7 @@ import Polyline
 /**
  A `Route` object defines a single route that the user can follow to visit a series of waypoints in order. The route object includes information about the route, such as its distance and expected travel time. Depending on the criteria used to calculate the route, the route object may also include detailed turn-by-turn instructions.
  
- Typically, you do not create instances of this class directly. Instead, you receive route objects when you request directions using the `Directions.calculate(_:completionHandler:)` method. However, if you use the `Directions.urlForCalculating(_:)` method instead, you can pass the results of the HTTP request into this class’s initializer. 
+ Typically, you do not create instances of this class directly. Instead, you receive route objects when you request directions using the `Directions.calculate(_:completionHandler:)` method. However, if you use the `Directions.url(forCalculating:)` method instead, you can pass the results of the HTTP request into this class’s initializer.
  */
 @objc(MBRoute)
 open class Route: NSObject, NSSecureCoding {
@@ -20,7 +20,7 @@ open class Route: NSObject, NSSecureCoding {
     /**
      Initializes a new route object with the given JSON dictionary representation and waypoints.
      
-     This initializer is intended for use in conjunction with the `Directions.urlForCalculating(_:)` method.
+     This initializer is intended for use in conjunction with the `Directions.url(forCalculating:)` method.
      
      - parameter json: A JSON dictionary representation of the route as returned by the Mapbox Directions API.
      - parameter waypoints: An array of waypoints that the route visits in chronological order.

--- a/MapboxDirections/MBRouteOptions.swift
+++ b/MapboxDirections/MBRouteOptions.swift
@@ -324,7 +324,7 @@ open class RouteOptions: NSObject, NSSecureCoding {
      - parameter json: The API response in JSON dictionary format.
      - returns: A tuple containing an array of waypoints and an array of routes.
      */
-    internal func response(_ json: JSONDictionary) -> ([Waypoint]?, [Route]?) {
+    internal func response(from json: JSONDictionary) -> ([Waypoint]?, [Route]?) {
         let waypoints = (json["waypoints"] as? [JSONDictionary])?.map { waypoint -> Waypoint in
             let location = waypoint["location"] as! [Double]
             let coordinate = CLLocationCoordinate2D(geoJSON: location)
@@ -420,7 +420,7 @@ open class RouteOptionsV4: RouteOptions {
         ]
     }
     
-    override func response(_ json: JSONDictionary) -> ([Waypoint]?, [Route]?) {
+    override func response(from json: JSONDictionary) -> ([Waypoint]?, [Route]?) {
         let sourceWaypoint = Waypoint(geoJSON: json["origin"] as! JSONDictionary)!
         let destinationWaypoint = Waypoint(geoJSON: json["destination"] as! JSONDictionary)!
         let intermediateWaypoints = (json["waypoints"] as! [JSONDictionary]).flatMap { Waypoint(geoJSON: $0) }

--- a/MapboxDirectionsTests/DirectionsTests.swift
+++ b/MapboxDirectionsTests/DirectionsTests.swift
@@ -30,7 +30,7 @@ class DirectionsTests: XCTestCase {
         
         let error: NSError? = nil
         
-        let resultError = Directions.descriptiveError(json, response: response, underlyingError: error)
+        let resultError = Directions.informativeError(describing: json, response: response, underlyingError: error)
         
         XCTAssertEqual(resultError.localizedFailureReason, "More than 600 requests have been made with this access token within a period of 1 minute.")
         XCTAssertEqual(resultError.localizedRecoverySuggestion, "Wait until November 18, 2016 at 9:16:24 AM GMT before retrying.")


### PR DESCRIPTION
Renamed some methods to better conform to Swift API design guidelines. The method’s base name shouldn’t contain a preposition. Additionally, the first argument’s label can only be omitted if the base name is a verb or verb phrase.

Also silenced a warning in the Objective-C example target about an unused return value.

/cc @frederoni @bsudekum