### PR TITLE
Clarify waypoint limit

### DIFF
--- a/MapboxDirections/MBRouteOptions.swift
+++ b/MapboxDirections/MBRouteOptions.swift
@@ -102,7 +102,7 @@ open class RouteOptions: NSObject, NSSecureCoding {
     /**
      Initializes a route options object for routes between the given waypoints and an optional profile identifier.
      
-     - parameter waypoints: An array of `Waypoint` objects representing locations that the route should visit in chronological order. The array should contain at least two waypoints (the source and destination) and at most 25 waypoints.
+     - parameter waypoints: An array of `Waypoint` objects representing locations that the route should visit in chronological order. The array should contain at least two waypoints (the source and destination) and at most 25 waypoints. (Some profiles, such as `MBDirectionsProfileIdentifierAutomobileAvoidingTraffic`, [may have lower limits](https://www.mapbox.com/api-documentation/#directions).)
      - parameter profileIdentifier: A string specifying the primary mode of transportation for the routes. This parameter, if set, should be set to `MBDirectionsProfileIdentifierAutomobile`, `MBDirectionsProfileIdentifierAutomobileAvoidingTraffic`, `MBDirectionsProfileIdentifierCycling`, or `MBDirectionsProfileIdentifierWalking`. `MBDirectionsProfileIdentifierAutomobile` is used by default.
      */
     public init(waypoints: [Waypoint], profileIdentifier: MBDirectionsProfileIdentifier? = nil) {


### PR DESCRIPTION
`MBDirectionsProfileIdentifierAutomobileAvoidingTraffic` has a much lower limit of three waypoints, per [the API documentation](https://www.mapbox.com/api-documentation/#directions).

/cc @ericrwolfe @bsudekum @danswick