### PR TITLE
Avoid traffic by default

### DIFF
--- a/MapboxDirections/MBRouteOptions.swift
+++ b/MapboxDirections/MBRouteOptions.swift
@@ -103,14 +103,14 @@ open class RouteOptions: NSObject, NSSecureCoding {
      Initializes a route options object for routes between the given waypoints and an optional profile identifier.
      
      - parameter waypoints: An array of `Waypoint` objects representing locations that the route should visit in chronological order. The array should contain at least two waypoints (the source and destination) and at most 25 waypoints.
-     - parameter profileIdentifier: A string specifying the primary mode of transportation for the routes. This parameter, if set, should be set to `MBDirectionsProfileIdentifierAutomobile`, `MBDirectionsProfileIdentifierAutomobileAvoidingTraffic`, `MBDirectionsProfileIdentifierCycling`, or `MBDirectionsProfileIdentifierWalking`. `MBDirectionsProfileIdentifierAutomobile` is used by default.
+     - parameter profileIdentifier: A string specifying the primary mode of transportation for the routes. This parameter, if set, should be set to `MBDirectionsProfileIdentifierAutomobile`, `MBDirectionsProfileIdentifierAutomobileAvoidingTraffic`, `MBDirectionsProfileIdentifierCycling`, or `MBDirectionsProfileIdentifierWalking`. `MBDirectionsProfileIdentifierAutomobileAvoidingTraffic` is used by default.
      */
     public init(waypoints: [Waypoint], profileIdentifier: MBDirectionsProfileIdentifier? = nil) {
         assert(waypoints.count >= 2, "A route requires at least a source and destination.")
         assert(waypoints.count <= 25, "A route may not have more than 25 waypoints.")
         
         self.waypoints = waypoints
-        self.profileIdentifier = profileIdentifier ?? .automobile
+        self.profileIdentifier = profileIdentifier ?? .automobileAvoidingTraffic
         self.allowsUTurnAtWaypoint = ![MBDirectionsProfileIdentifier.automobile.rawValue, MBDirectionsProfileIdentifier.automobileAvoidingTraffic.rawValue].contains(self.profileIdentifier.rawValue)
     }
     


### PR DESCRIPTION
In areas without sufficient traffic congestion data, `MBDirectionsProfileIdentifierAutomobileAvoidingTraffic` falls back to `MBDirectionsProfileIdentifierAutomobile` anyways, according to [the API documentation](https://www.mapbox.com/api-documentation/#directions).

Developers would naturally expect traffic avoidance to be turned on by default, especially when using this library in conjunction with the navigation SDK. The downsides are that far fewer waypoints and no alternative routes are supported with the traffic-avoiding profile. Therefore, it may make sense to hold this PR until either of these limitations is eased on the server side.

/cc @ericrwolfe @bsudekum @frederoni