### PR TITLE
Expose exit numbers on route steps

### DIFF
--- a/MapboxDirectionsTests/RouteStepTests.swift
+++ b/MapboxDirectionsTests/RouteStepTests.swift
@@ -3,60 +3,62 @@ import XCTest
 
 class RoadTests: XCTestCase {
     func testEmpty() {
-        let r = Road(name: "", ref: nil, destination: nil, rotaryName: nil)
+        let r = Road(name: "", ref: nil, exits: nil, destination: nil, rotaryName: nil)
         XCTAssertNil(r.names)
         XCTAssertNil(r.codes)
+        XCTAssertNil(r.exitCodes)
         XCTAssertNil(r.destinations)
         XCTAssertNil(r.destinationCodes)
         XCTAssertNil(r.rotaryNames)
+        
     }
 
     func testNamesCodes() {
         var r: Road
 
         // Name only
-        r = Road(name: "Way Name", ref: nil, destination: nil, rotaryName: nil)
+        r = Road(name: "Way Name", ref: nil, exits: nil, destination: nil, rotaryName: nil)
         XCTAssertEqual(r.names ?? [], [ "Way Name" ])
         XCTAssertNil(r.codes)
-        r = Road(name: "Way Name 1; Way Name 2", ref: nil, destination: nil, rotaryName: nil)
+        r = Road(name: "Way Name 1; Way Name 2", ref: nil, exits: nil, destination: nil, rotaryName: nil)
         XCTAssertEqual(r.names ?? [], [ "Way Name 1", "Way Name 2" ])
         XCTAssertNil(r.codes)
 
         // Ref only
-        r = Road(name: "", ref: "Ref 1", destination: nil, rotaryName: nil)
+        r = Road(name: "", ref: "Ref 1", exits: nil, destination: nil, rotaryName: nil)
         XCTAssertNil(r.names)
         XCTAssertEqual(r.codes ?? [], [ "Ref 1" ])
-        r = Road(name: "", ref: "Ref 1; Ref 2", destination: nil, rotaryName: nil)
+        r = Road(name: "", ref: "Ref 1; Ref 2", exits: nil, destination: nil, rotaryName: nil)
         XCTAssertNil(r.names)
         XCTAssertEqual(r.codes ?? [], [ "Ref 1", "Ref 2" ])
 
         // Separate Name and Ref
-        r = Road(name: "Way Name", ref: "Ref 1", destination: nil, rotaryName: nil)
+        r = Road(name: "Way Name", ref: "Ref 1", exits: nil, destination: nil, rotaryName: nil)
         XCTAssertEqual(r.names ?? [], [ "Way Name" ])
         XCTAssertEqual(r.codes ?? [], [ "Ref 1" ])
-        r = Road(name: "Way Name 1; Way Name 2", ref: "Ref 1; Ref 2", destination: nil, rotaryName: nil)
+        r = Road(name: "Way Name 1; Way Name 2", ref: "Ref 1; Ref 2", exits: nil, destination: nil, rotaryName: nil)
         XCTAssertEqual(r.names ?? [], [ "Way Name 1", "Way Name 2" ])
         XCTAssertEqual(r.codes ?? [], [ "Ref 1", "Ref 2" ])
-        r = Road(name: "Way Name 1;Way Name 2", ref: "Ref 1;Ref 2", destination: nil, rotaryName: nil)
+        r = Road(name: "Way Name 1;Way Name 2", ref: "Ref 1;Ref 2", exits: nil, destination: nil, rotaryName: nil)
         XCTAssertEqual(r.names ?? [], [ "Way Name 1", "Way Name 2" ])
         XCTAssertEqual(r.codes ?? [], [ "Ref 1", "Ref 2" ])
 
         // Name in Ref (Mapbox Directions API v4)
-        r = Road(name: "Way Name (Ref)", ref: nil, destination: nil, rotaryName: nil)
+        r = Road(name: "Way Name (Ref)", ref: nil, exits: nil, destination: nil, rotaryName: nil)
         XCTAssertEqual(r.names ?? [], [ "Way Name" ])
         XCTAssertEqual(r.codes ?? [], [ "Ref" ])
-        r = Road(name: "Way Name 1; Way Name 2 (Ref 1; Ref 2)", ref: nil, destination: nil, rotaryName: nil)
+        r = Road(name: "Way Name 1; Way Name 2 (Ref 1; Ref 2)", ref: nil, exits: nil, destination: nil, rotaryName: nil)
         XCTAssertEqual(r.names ?? [], [ "Way Name 1", "Way Name 2"])
         XCTAssertEqual(r.codes ?? [], [ "Ref 1", "Ref 2" ])
 
         // Ref duplicated in Name (Mapbox Directions API v5)
-        r = Road(name: "Way Name (Ref)", ref: "Ref", destination: nil, rotaryName: nil)
+        r = Road(name: "Way Name (Ref)", ref: "Ref", exits: nil, destination: nil, rotaryName: nil)
         XCTAssertEqual(r.names ?? [], [ "Way Name" ])
         XCTAssertEqual(r.codes ?? [], [ "Ref" ])
-        r = Road(name: "Way Name 1; Way Name 2 (Ref 1; Ref 2)", ref: "Ref 1; Ref 2", destination: nil, rotaryName: nil)
+        r = Road(name: "Way Name 1; Way Name 2 (Ref 1; Ref 2)", ref: "Ref 1; Ref 2", exits: nil, destination: nil, rotaryName: nil)
         XCTAssertEqual(r.names ?? [], [ "Way Name 1", "Way Name 2"])
         XCTAssertEqual(r.codes ?? [], [ "Ref 1", "Ref 2" ])
-        r = Road(name: "Ref 1; Ref 2", ref: "Ref 1; Ref 2", destination: nil, rotaryName: nil)
+        r = Road(name: "Ref 1; Ref 2", ref: "Ref 1; Ref 2", exits: nil, destination: nil, rotaryName: nil)
         XCTAssertNil(r.names)
         XCTAssertEqual(r.codes ?? [], [ "Ref 1", "Ref 2" ])
     }
@@ -64,28 +66,38 @@ class RoadTests: XCTestCase {
     func testRotaryNames() {
         var r: Road
 
-        r = Road(name: "", ref: nil, destination: nil, rotaryName: "Rotary Name")
+        r = Road(name: "", ref: nil, exits: nil, destination: nil, rotaryName: "Rotary Name")
         XCTAssertEqual(r.rotaryNames ?? [], [ "Rotary Name" ])
-        r = Road(name: "", ref: nil, destination: nil, rotaryName: "Rotary Name 1;Rotary Name 2")
+        r = Road(name: "", ref: nil, exits: nil
+            , destination: nil, rotaryName: "Rotary Name 1;Rotary Name 2")
         XCTAssertEqual(r.rotaryNames ?? [], [ "Rotary Name 1", "Rotary Name 2" ])
+    }
+
+    func testExitCodes() {
+        var r: Road
+
+        r = Road(name: "", ref: nil, exits: "123 A", destination: nil, rotaryName: nil)
+        XCTAssertEqual(r.exitCodes ?? [], [ "123 A" ])
+        r = Road(name: "", ref: nil, exits: "123A,123B", destination: nil, rotaryName: nil)
+        XCTAssertEqual(r.exitCodes ?? [], [ "123A", "123B" ])
     }
 
     func testDestinations() {
         var r: Road
 
         // No ref
-        r = Road(name: "", ref: nil, destination: "Destination", rotaryName: nil)
+        r = Road(name: "", ref: nil, exits: nil, destination: "Destination", rotaryName: nil)
         XCTAssertEqual(r.destinations ?? [], [ "Destination" ])
         XCTAssertNil(r.destinationCodes)
-        r = Road(name: "", ref: nil, destination: "Destination 1, Destination 2", rotaryName: nil)
+        r = Road(name: "", ref: nil, exits: nil, destination: "Destination 1, Destination 2", rotaryName: nil)
         XCTAssertEqual(r.destinations ?? [], [ "Destination 1", "Destination 2" ])
         XCTAssertNil(r.destinationCodes)
 
         // With ref
-        r = Road(name: "", ref: nil, destination: "Ref 1: Destination", rotaryName: nil)
+        r = Road(name: "", ref: nil, exits: nil, destination: "Ref 1: Destination", rotaryName: nil)
         XCTAssertEqual(r.destinations ?? [], [ "Destination" ])
         XCTAssertEqual(r.destinationCodes ?? [], [ "Ref 1" ])
-        r = Road(name: "", ref: nil, destination: "Ref 1, Ref 2: Destination 1, Destination 2, Destination 3", rotaryName: nil)
+        r = Road(name: "", ref: nil, exits: nil, destination: "Ref 1, Ref 2: Destination 1, Destination 2, Destination 3", rotaryName: nil)
         XCTAssertEqual(r.destinations ?? [], [ "Destination 1", "Destination 2", "Destination 3" ])
         XCTAssertEqual(r.destinationCodes ?? [], [ "Ref 1", "Ref 2" ])
     }


### PR DESCRIPTION
Added an `exitCodes` property to RouteStep. It contains the maneuver’s exit number.

This property has this odd name for consistency with `codes` and `destinationCodes`. Even though `exitNumber` might be a more natural name for the property, I wanted to avoid the possibility of a developer thinking it would be a number (e.g., NSNumber) and experiencing some friction as a result.

Fixes #146. Hold until the `exits` property goes live in the Directions API.

/cc @bsudekum @willwhite @frederoni