### PR TITLE
Split exit codes by semicolon

### DIFF
--- a/MapboxDirections/MBRouteStep.swift
+++ b/MapboxDirections/MBRouteStep.swift
@@ -447,7 +447,7 @@ struct Road {
             self.destinations = destination?.tagValues(separatedBy: ",")
         }
         
-        self.exitCodes = exits?.tagValues(separatedBy: ",")
+        self.exitCodes = exits?.tagValues(separatedBy: ";")
         self.codes = codes
         self.rotaryNames = rotaryName?.tagValues(separatedBy: ";")
     }

--- a/MapboxDirectionsTests/RouteStepTests.swift
+++ b/MapboxDirectionsTests/RouteStepTests.swift
@@ -78,7 +78,7 @@ class RoadTests: XCTestCase {
 
         r = Road(name: "", ref: nil, exits: "123 A", destination: nil, rotaryName: nil)
         XCTAssertEqual(r.exitCodes ?? [], [ "123 A" ])
-        r = Road(name: "", ref: nil, exits: "123A,123B", destination: nil, rotaryName: nil)
+        r = Road(name: "", ref: nil, exits: "123A;123B", destination: nil, rotaryName: nil)
         XCTAssertEqual(r.exitCodes ?? [], [ "123A", "123B" ])
     }
 


### PR DESCRIPTION
As seen in [this OSRM response](http://map.project-osrm.org/?z=18&center=39.102957%2C-84.524158&loc=39.103694%2C-84.526727&loc=39.101800%2C-84.523154&hl=en&alt=0), exit numbers are delimited by semicolons ([as in OpenStreetMap](http://www.openstreetmap.org/way/19051476)) rather than commas (as with route numbers and destinations).

/cc @freenerd