### PR TITLE
Customize variables Quick Look for various types

### DIFF
--- a/MapboxDirections/MBRoute.swift
+++ b/MapboxDirections/MBRoute.swift
@@ -161,6 +161,13 @@ open class Route: NSObject, NSSecureCoding {
      The route options object’s profileIdentifier property reflects the primary mode of transportation used for the route. Individual steps along the route might use different modes of transportation as necessary.
      */
     open let routeOptions: RouteOptions
+    
+    func debugQuickLookObject() -> Any? {
+        if let coordinates = coordinates {
+            return debugQuickLookURL(illustrating: coordinates, profileIdentifier: routeOptions.profileIdentifier)
+        }
+        return nil
+    }
 }
 
 // MARK: Support for Directions API v4

--- a/MapboxDirections/MBRouteLeg.swift
+++ b/MapboxDirections/MBRouteLeg.swift
@@ -221,6 +221,14 @@ open class RouteLeg: NSObject, NSSecureCoding {
      The value of this property is `MBDirectionsProfileIdentifierAutomobile`, `MBDirectionsProfileIdentifierAutomobileAvoidingTraffic`, `MBDirectionsProfileIdentifierCycling`, or `MBDirectionsProfileIdentifierWalking`, depending on the `profileIdentifier` property of the original `RouteOptions` object. This property reflects the primary mode of transportation used for the route leg. Individual steps along the route leg might use different modes of transportation as necessary.
      */
     open let profileIdentifier: MBDirectionsProfileIdentifier
+    
+    func debugQuickLookObject() -> Any? {
+        let coordinates = steps.reduce([], { $0 + ($1.coordinates ?? []) })
+        guard !coordinates.isEmpty else {
+            return nil
+        }
+        return debugQuickLookURL(illustrating: coordinates)
+    }
 }
 
 // MARK: Support for Directions API v4

--- a/MapboxDirections/MBWaypoint.swift
+++ b/MapboxDirections/MBWaypoint.swift
@@ -146,6 +146,10 @@ open class Waypoint: NSObject, NSCopying, NSSecureCoding {
     open override var description: String {
         return name ?? "<latitude: \(coordinate.latitude); longitude: \(coordinate.longitude)>"
     }
+    
+    func debugQuickLookObject() -> Any {
+        return CLLocation(coordinate: coordinate, altitude: 0, horizontalAccuracy: coordinateAccuracy, verticalAccuracy: -1, course: heading, speed: -1, timestamp: Date())
+    }
 }
 
 // MARK: Support for Directions API v4


### PR DESCRIPTION
Customized Quick Look for Route, RouteLeg, and RouteStep to display a static map with the geometry overlaid, powered by the Mapbox Static API. Customized Quick Look for Waypoint to display the coordinate using Xcode’s built-in coordinate viewer.

The static map uses the Mapbox Streets style for the `.automobile` profile, Traffic Day for `.automobileAvoidingTraffic`, and Outdoors for `.cycling` and `.walking`.

<img width="1392" alt="automobile" src="https://user-images.githubusercontent.com/1231218/28156929-861f54b0-6769-11e7-9d3f-d24d684cb244.png">
<img width="1392" alt="automobileavoidingtraffic" src="https://user-images.githubusercontent.com/1231218/28156930-8625baee-6769-11e7-86ff-a5533ec0f963.png">

Fixes #150.

/ref mapbox/mapbox-gl-native#9484
/cc @frederoni @bsudekum