### PR TITLE
Use time format in error that is consistent across platforms

### DIFF
--- a/MapboxDirections/MBDirections.swift
+++ b/MapboxDirections/MBDirections.swift
@@ -260,7 +260,7 @@ open class Directions: NSObject {
                     failureReason = "More than \(formattedCount) requests have been made with this access token within a period of \(formattedInterval)."
                 }
                 if let rolloverTime = response.rateLimitResetTime {
-                    let formattedDate = DateFormatter.localizedString(from: rolloverTime, dateStyle: .long, timeStyle: .full)
+                    let formattedDate = DateFormatter.localizedString(from: rolloverTime, dateStyle: .long, timeStyle: .long)
                     recoverySuggestion = "Wait until \(formattedDate) before retrying."
                 }
             default:


### PR DESCRIPTION
When using [`DateFormatter.Style.full`](https://developer.apple.com/documentation/foundation/dateformatter.style/1408961-full) on macOS 10.12.5+, it will return full timezone names (e.g., Greenwich Mean Time) and not abbreviations (GMT), as iOS-based systems do. Frankly, macOS seems more correct.

Switching to `.long` for the time formatter style results in consistent output (abbreviations) across all platforms.

This [started failing on CI](https://www.bitrise.io/build/fb2a4f13c85d2d6) when I updated from [Xcode 8.2.1 on macOS 10.12.2](https://github.com/bitrise-io/bitrise.io/blob/b79338f6f716be3a180f26601e8eefe8d9fe945c/system_reports/osx-xcode-8.2.x.log) to [Xcode 8.3.3 on macOS 10.12.5](https://github.com/bitrise-io/bitrise.io/blob/b79338f6f716be3a180f26601e8eefe8d9fe945c/system_reports/osx-xcode-8.3.x.log):

>   testRateLimitErrorParsing, XCTAssertEqual failed: ("Optional("Wait until November 18, 2016 at 9:16:24 AM Greenwich Mean Time before retrying.")") is not equal to ("Optional("Wait until November 18, 2016 at 9:16:24 AM GMT before retrying.")") - 
>   /Users/vagrant/git/MapboxDirectionsTests/DirectionsTests.swift:36
>   ```
>         XCTAssertEqual(resultError.localizedFailureReason, "More than 600 requests have been made with this access token within a period of 1 minute.")
>         XCTAssertEqual(resultError.localizedRecoverySuggestion, "Wait until November 18, 2016 at 9:16:24 AM GMT before retrying.")
>     }
>   ```

/cc @1ec5 @frederoni 