### PR TITLE
Add accessToken used to make request to Route

### DIFF
--- a/MapboxDirections/MBDirections.swift
+++ b/MapboxDirections/MBDirections.swift
@@ -171,7 +171,7 @@ open class Directions: NSObject {
             if let routes = response.1 {
                 for route in routes {
                     route.accessToken = self.accessToken
-                    route.host = self.apiEndpoint
+                    route.apiEndpoint = self.apiEndpoint
                 }
             }
             completionHandler(response.0, response.1, nil)

--- a/MapboxDirections/MBDirections.swift
+++ b/MapboxDirections/MBDirections.swift
@@ -168,6 +168,11 @@ open class Directions: NSObject {
         let url = self.url(forCalculating: options)
         let task = dataTask(with: url, completionHandler: { (json) in
             let response = options.response(from: json)
+            if let routes = response.1 {
+                for route in routes {
+                    route.accessToken = self.accessToken
+                }
+            }
             completionHandler(response.0, response.1, nil)
         }) { (error) in
             completionHandler(nil, nil, error)

--- a/MapboxDirections/MBDirections.swift
+++ b/MapboxDirections/MBDirections.swift
@@ -171,6 +171,7 @@ open class Directions: NSObject {
             if let routes = response.1 {
                 for route in routes {
                     route.accessToken = self.accessToken
+                    route.host = self.apiEndpoint
                 }
             }
             completionHandler(response.0, response.1, nil)

--- a/MapboxDirections/MBRoute.swift
+++ b/MapboxDirections/MBRoute.swift
@@ -162,6 +162,11 @@ open class Route: NSObject, NSSecureCoding {
      */
     open let routeOptions: RouteOptions
     
+    /**
+     The access token used to make the directions request.
+     */
+    open var accessToken: String! = nil
+    
     func debugQuickLookObject() -> Any? {
         if let coordinates = coordinates {
             return debugQuickLookURL(illustrating: coordinates, profileIdentifier: routeOptions.profileIdentifier)

--- a/MapboxDirections/MBRoute.swift
+++ b/MapboxDirections/MBRoute.swift
@@ -165,9 +165,16 @@ open class Route: NSObject, NSSecureCoding {
     /**
      The access token used to make the directions request.
      
-     Only set after a request is made via `Directions.calculate(_:completionHandler:)`.
+     Only set if a request is made via `Directions.calculate(_:completionHandler:)`.
      */
     open var accessToken: String?
+    
+    /**
+     The endpoint used to make the directions request.
+     
+     Only set if a request is made via `Directions.calculate(_:completionHandler:)`.
+     */
+    open var apiEndpoint: String?
     
     func debugQuickLookObject() -> Any? {
         if let coordinates = coordinates {

--- a/MapboxDirections/MBRoute.swift
+++ b/MapboxDirections/MBRoute.swift
@@ -164,8 +164,10 @@ open class Route: NSObject, NSSecureCoding {
     
     /**
      The access token used to make the directions request.
+     
+     Only set after a request is made via `Directions.calculate(_:completionHandler:)`.
      */
-    open var accessToken: String! = nil
+    open var accessToken: String?
     
     func debugQuickLookObject() -> Any? {
         if let coordinates = coordinates {

--- a/MapboxDirections/MBRoute.swift
+++ b/MapboxDirections/MBRoute.swift
@@ -174,7 +174,7 @@ open class Route: NSObject, NSSecureCoding {
      
      Only set if a request is made via `Directions.calculate(_:completionHandler:)`.
      */
-    open var apiEndpoint: String?
+    open var apiEndpoint: URL?
     
     func debugQuickLookObject() -> Any? {
         if let coordinates = coordinates {

--- a/MapboxDirections/MBRoute.swift
+++ b/MapboxDirections/MBRoute.swift
@@ -163,16 +163,16 @@ open class Route: NSObject, NSSecureCoding {
     open let routeOptions: RouteOptions
     
     /**
-     The access token used to make the directions request.
+     The [access token](https://www.mapbox.com/help/define-access-token/) used to make the directions request.
      
-     Only set if a request is made via `Directions.calculate(_:completionHandler:)`.
+     This property is set automatically if a request is made via Directions.calculate(_:completionHandler:).
      */
     open var accessToken: String?
     
     /**
      The endpoint used to make the directions request.
      
-     Only set if a request is made via `Directions.calculate(_:completionHandler:)`.
+     This property is set automatically if a request is made via Directions.calculate(_:completionHandler:).
      */
     open var apiEndpoint: URL?
     

--- a/MapboxDirectionsTests/V4Tests.swift
+++ b/MapboxDirectionsTests/V4Tests.swift
@@ -54,6 +54,7 @@ class V4Tests: XCTestCase {
         XCTAssertNotNil(route!.coordinates)
         XCTAssertEqual(route!.coordinates!.count, 28375)
         XCTAssertEqual(route!.accessToken, BogusToken)
+        XCTAssertEqual(route!.apiEndpoint, URL(string: "https://api.mapbox.com"))
         
         XCTAssertEqual(round(route!.coordinates!.first!.latitude), 38)
         XCTAssertEqual(round(route!.coordinates!.first!.longitude), -122)

--- a/MapboxDirectionsTests/V4Tests.swift
+++ b/MapboxDirectionsTests/V4Tests.swift
@@ -53,6 +53,7 @@ class V4Tests: XCTestCase {
         XCTAssertNotNil(route)
         XCTAssertNotNil(route!.coordinates)
         XCTAssertEqual(route!.coordinates!.count, 28375)
+        XCTAssertEqual(route!.accessToken, BogusToken)
         
         XCTAssertEqual(round(route!.coordinates!.first!.latitude), 38)
         XCTAssertEqual(round(route!.coordinates!.first!.longitude), -122)

--- a/MapboxDirectionsTests/V5Tests.swift
+++ b/MapboxDirectionsTests/V5Tests.swift
@@ -55,6 +55,7 @@ class V5Tests: XCTestCase {
         XCTAssertNotNil(route)
         XCTAssertNotNil(route!.coordinates)
         XCTAssertEqual(route!.coordinates!.count, 28_442)
+        XCTAssertEqual(route!.accessToken, BogusToken)
         
         // confirming actual decoded values is important because the Directions API
         // uses an atypical precision level for polyline encoding

--- a/MapboxDirectionsTests/V5Tests.swift
+++ b/MapboxDirectionsTests/V5Tests.swift
@@ -56,6 +56,8 @@ class V5Tests: XCTestCase {
         XCTAssertNotNil(route!.coordinates)
         XCTAssertEqual(route!.coordinates!.count, 28_442)
         XCTAssertEqual(route!.accessToken, BogusToken)
+        XCTAssertEqual(route!.apiEndpoint, URL(string: "https://api.mapbox.com"))
+        
         
         // confirming actual decoded values is important because the Directions API
         // uses an atypical precision level for polyline encoding


### PR DESCRIPTION
It's helpful to know what access token was used to make the directions request. This adds `acccessToken` to the `Route` class.

/cc @1ec5 