### PR TITLE
Fix Intersection coding

### DIFF
--- a/IntersectionTests.swift
+++ b/IntersectionTests.swift
@@ -1,0 +1,38 @@
+import XCTest
+@testable import MapboxDirections
+
+class IntersectionTests: XCTestCase {
+    func testCoding() {
+        let json: JSONDictionary = [
+            "classes": ["toll", "restricted"],
+            "out": 0,
+            "entry": [true],
+            "bearings": [80.0],
+            "location": [-122.420018, 37.78009],
+        ]
+        let intersection = Intersection(json: json)
+        
+        // Encode and decode the intersection securely.
+        // This may raise an Objective-C exception if an error is encountered which will fail the tests.
+        
+        let encodedData = NSMutableData()
+        let keyedArchiver = NSKeyedArchiver(forWritingWith: encodedData)
+        keyedArchiver.requiresSecureCoding = true
+        keyedArchiver.encode(intersection, forKey: "intersection")
+        keyedArchiver.finishEncoding()
+        
+        let keyedUnarchiver = NSKeyedUnarchiver(forReadingWith: encodedData as Data)
+        keyedUnarchiver.requiresSecureCoding = true
+        let unarchivedIntersection = keyedUnarchiver.decodeObject(of: Intersection.self, forKey: "intersection")!
+        keyedUnarchiver.finishDecoding()
+        
+        XCTAssertNotNil(unarchivedIntersection)
+        
+        XCTAssertEqual(unarchivedIntersection.location.latitude, unarchivedIntersection.location.latitude)
+        XCTAssertEqual(unarchivedIntersection.location.longitude, unarchivedIntersection.location.longitude)
+        XCTAssertEqual(unarchivedIntersection.headings, unarchivedIntersection.headings)
+        XCTAssertEqual(unarchivedIntersection.outletIndex, unarchivedIntersection.outletIndex)
+        XCTAssertEqual(unarchivedIntersection.outletIndexes, unarchivedIntersection.outletIndexes)
+        XCTAssertEqual(unarchivedIntersection.outletRoadClasses, unarchivedIntersection.outletRoadClasses)
+    }
+}

--- a/MapboxDirections.xcodeproj/project.pbxproj
+++ b/MapboxDirections.xcodeproj/project.pbxproj
@@ -121,6 +121,9 @@
 		DADD27F31E5ABD4300D31FAD /* Mapbox.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DADD27F21E5ABD4300D31FAD /* Mapbox.framework */; };
 		DADD27F41E5ABD6000D31FAD /* Mapbox.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DADD27F21E5ABD4300D31FAD /* Mapbox.framework */; };
 		DADD27F71E5AC8E900D31FAD /* MapboxDirections.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DA6C9D881CAE442B00094FBC /* MapboxDirections.framework */; };
+		DAE33A1B1F215DF600C06039 /* IntersectionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAE33A1A1F215DF600C06039 /* IntersectionTests.swift */; };
+		DAE33A1C1F215DF600C06039 /* IntersectionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAE33A1A1F215DF600C06039 /* IntersectionTests.swift */; };
+		DAE33A1D1F215DF600C06039 /* IntersectionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAE33A1A1F215DF600C06039 /* IntersectionTests.swift */; };
 		DAE9E0F41EB7DE2E001E8E8B /* RouteOptionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAE9E0F31EB7DE2E001E8E8B /* RouteOptionsTests.swift */; };
 		DAE9E0F51EB7DE2E001E8E8B /* RouteOptionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAE9E0F31EB7DE2E001E8E8B /* RouteOptionsTests.swift */; };
 		DAE9E0F61EB7DE2E001E8E8B /* RouteOptionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAE9E0F31EB7DE2E001E8E8B /* RouteOptionsTests.swift */; };
@@ -219,6 +222,7 @@
 		DADD27EC1E5AB0EB00D31FAD /* ViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ViewController.h; sourceTree = "<group>"; };
 		DADD27ED1E5AB0EB00D31FAD /* ViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ViewController.m; sourceTree = "<group>"; };
 		DADD27F21E5ABD4300D31FAD /* Mapbox.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Mapbox.framework; path = Carthage/Build/iOS/Mapbox.framework; sourceTree = "<group>"; };
+		DAE33A1A1F215DF600C06039 /* IntersectionTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = IntersectionTests.swift; sourceTree = SOURCE_ROOT; };
 		DAE9E0F31EB7DE2E001E8E8B /* RouteOptionsTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = RouteOptionsTests.swift; path = MapboxDirectionsTests/RouteOptionsTests.swift; sourceTree = SOURCE_ROOT; };
 		DD6254731AE70CB700017857 /* MBDirections.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MBDirections.swift; sourceTree = "<group>"; };
 		F448F82A1DDCC5B6000BC343 /* Polyline.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Polyline.framework; path = Carthage/Build/iOS/Polyline.framework; sourceTree = "<group>"; };
@@ -364,6 +368,7 @@
 				DA6C9DAB1CAEC72800094FBC /* V5Tests.swift */,
 				DA6C9DB11CAECA0E00094FBC /* Fixture.swift */,
 				C5247D701E818A24004B6154 /* AnnotationTests.swift */,
+				DAE33A1A1F215DF600C06039 /* IntersectionTests.swift */,
 				DA6C9D9A1CAE442B00094FBC /* Info.plist */,
 				DA6C9DAD1CAEC93800094FBC /* Fixtures */,
 			);
@@ -936,6 +941,7 @@
 				C53A02291E92C27A009837BD /* AnnotationTests.swift in Sources */,
 				DA1A10CD1D00F972009F82FA /* V5Tests.swift in Sources */,
 				DA737EE91D0611CB005BDA16 /* V4Tests.swift in Sources */,
+				DAE33A1C1F215DF600C06039 /* IntersectionTests.swift in Sources */,
 				DA1A10CE1D00F972009F82FA /* Fixture.swift in Sources */,
 				DA1A110C1D01045E009F82FA /* DirectionsTests.swift in Sources */,
 				F4D785F01DDD82C100FF4665 /* RouteStepTests.swift in Sources */,
@@ -970,6 +976,7 @@
 				C53A022A1E92C27B009837BD /* AnnotationTests.swift in Sources */,
 				DA1A10F41D010251009F82FA /* V5Tests.swift in Sources */,
 				DA737EEA1D0611CB005BDA16 /* V4Tests.swift in Sources */,
+				DAE33A1D1F215DF600C06039 /* IntersectionTests.swift in Sources */,
 				DA1A10F51D010251009F82FA /* Fixture.swift in Sources */,
 				DA1A110D1D01045E009F82FA /* DirectionsTests.swift in Sources */,
 				F4D785F11DDD82C100FF4665 /* RouteStepTests.swift in Sources */,
@@ -1024,6 +1031,7 @@
 				C5247D711E818A24004B6154 /* AnnotationTests.swift in Sources */,
 				DA6C9DAC1CAEC72800094FBC /* V5Tests.swift in Sources */,
 				DA737EE81D0611CB005BDA16 /* V4Tests.swift in Sources */,
+				DAE33A1B1F215DF600C06039 /* IntersectionTests.swift in Sources */,
 				DA6C9DB21CAECA0E00094FBC /* Fixture.swift in Sources */,
 				DA1A110B1D01045E009F82FA /* DirectionsTests.swift in Sources */,
 				F4D785EF1DDD82C100FF4665 /* RouteStepTests.swift in Sources */,

--- a/MapboxDirectionsTests/V5Tests.swift
+++ b/MapboxDirectionsTests/V5Tests.swift
@@ -79,7 +79,7 @@ class V5Tests: XCTestCase {
         XCTAssertNotNil(firstStepIntersections)
         let firstIntersection = firstStepIntersections?.first
         XCTAssertNotNil(firstIntersection)
-        let roadClasses = firstIntersection?.roadClasses
+        let roadClasses = firstIntersection?.outletRoadClasses
         XCTAssertNotNil(roadClasses)
         XCTAssertTrue(roadClasses?.contains([.toll, .restricted]) ?? false)
         


### PR DESCRIPTION
Fixed some issues preventing Intersection from round-tripping. Added tests to ensure roundtrippability. Also renamed `Intersection.roadClasses` to `outletRoadClasses`, since multiple roads could lead to or from the intersection.

/cc @bsudekum