### PR TITLE
[Hold] Update usages of map() to compile in Xcode 9

### DIFF
--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,3 +1,3 @@
-binary "https://www.mapbox.com/ios-sdk/Mapbox-iOS-SDK.json" "3.5.4"
+binary "https://www.mapbox.com/ios-sdk/Mapbox-iOS-SDK.json" "3.6.1"
 github "AliSoftware/OHHTTPStubs" "6.0.0"
 github "raphaelmor/Polyline" "v4.1.1"

--- a/MapboxDirections.xcodeproj/project.pbxproj
+++ b/MapboxDirections.xcodeproj/project.pbxproj
@@ -752,11 +752,11 @@
 					};
 					DA6C9D871CAE442B00094FBC = {
 						CreatedOnToolsVersion = 7.3;
-						LastSwiftMigration = 0800;
+						LastSwiftMigration = 0900;
 					};
 					DA6C9D901CAE442B00094FBC = {
 						CreatedOnToolsVersion = 7.3;
-						LastSwiftMigration = 0800;
+						LastSwiftMigration = 0900;
 					};
 					DADD27B41E5AAAD800D31FAD = {
 						CreatedOnToolsVersion = 8.2.1;
@@ -1360,7 +1360,8 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.mapbox.MapboxDirections;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
-				SWIFT_VERSION = 3.0;
+				SWIFT_SWIFT3_OBJC_INFERENCE = Off;
+				SWIFT_VERSION = 4.0;
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
 			};
@@ -1387,7 +1388,8 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.mapbox.MapboxDirections;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
-				SWIFT_VERSION = 3.0;
+				SWIFT_SWIFT3_OBJC_INFERENCE = Off;
+				SWIFT_VERSION = 4.0;
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
 			};
@@ -1407,7 +1409,8 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) $(PROJECT_DIR)/Carthage/Build/iOS @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.mapbox.MapboxDirectionsTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 3.0;
+				SWIFT_SWIFT3_OBJC_INFERENCE = Off;
+				SWIFT_VERSION = 4.0;
 			};
 			name = Debug;
 		};
@@ -1424,7 +1427,8 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) $(PROJECT_DIR)/Carthage/Build/iOS @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.mapbox.MapboxDirectionsTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 3.0;
+				SWIFT_SWIFT3_OBJC_INFERENCE = Off;
+				SWIFT_VERSION = 4.0;
 			};
 			name = Release;
 		};
@@ -1447,7 +1451,7 @@
 				PRODUCT_MODULE_NAME = DirectionsExampleSwift;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
-				SWIFT_VERSION = 3.0;
+				SWIFT_VERSION = 4.0;
 			};
 			name = Debug;
 		};
@@ -1468,7 +1472,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.mapbox.Directions.Swift;
 				PRODUCT_MODULE_NAME = DirectionsExampleSwift;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 3.0;
+				SWIFT_VERSION = 4.0;
 			};
 			name = Release;
 		};

--- a/MapboxDirections/MBIntersection.swift
+++ b/MapboxDirections/MBIntersection.swift
@@ -62,7 +62,10 @@ public class Intersection: NSObject, NSSecureCoding {
         headings = json["bearings"] as! [CLLocationDirection]
         
         let outletsArray = json["entry"] as! [Bool]
-        let outletIndexes = outletsArray.enumerated().filter{ $1 }.map { $0.offset }
+        let outletIndexes = outletsArray.enumerated().filter { (arg) -> Bool in
+            let (_, element) = arg
+            return element
+        }.map { $0.offset }
         self.outletIndexes = IndexSet(outletIndexes)
         
         approachIndex = json["in"] as? Int ?? -1

--- a/MapboxDirections/MBRoute.swift
+++ b/MapboxDirections/MBRoute.swift
@@ -30,8 +30,9 @@ open class Route: NSObject, NSSecureCoding {
         // Associate each leg JSON with a source and destination. The sequence of destinations is offset by one from the sequence of sources.
         let legInfo = zip(zip(waypoints.prefix(upTo: waypoints.endIndex - 1), waypoints.suffix(from: 1)),
                           json["legs"] as? [JSONDictionary] ?? [])
-        let legs = legInfo.map { (endpoints, json) -> RouteLeg in
-            RouteLeg(json: json, source: endpoints.0, destination: endpoints.1, profileIdentifier: routeOptions.profileIdentifier)
+        let legs = legInfo.map { (arg) -> RouteLeg in
+            let (endpoints, json) = arg
+            return RouteLeg(json: json, source: endpoints.0, destination: endpoints.1, profileIdentifier: routeOptions.profileIdentifier)
         }
         let distance = json["distance"] as! Double
         let expectedTravelTime = json["duration"] as! Double

--- a/MapboxDirections/MBRouteOptions.swift
+++ b/MapboxDirections/MBRouteOptions.swift
@@ -325,12 +325,13 @@ open class RouteOptions: NSObject, NSSecureCoding {
      - returns: A tuple containing an array of waypoints and an array of routes.
      */
     internal func response(from json: JSONDictionary) -> ([Waypoint]?, [Route]?) {
-        var namedWaypoints: [Waypoint]
+        var namedWaypoints = [Waypoint]()
         if let waypoints = (json["waypoints"] as? [JSONDictionary]) {
-            namedWaypoints = zip(waypoints, self.waypoints).map { (json, waypoint) -> Waypoint in
-                let location = json["location"] as! [Double]
+            for (index, element) in waypoints.enumerated() {
+                let location = element["location"] as! [Double]
                 let coordinate = CLLocationCoordinate2D(geoJSON: location)
-                return Waypoint(coordinate: coordinate, name: waypoint.name ?? json["name"] as? String)
+                let waypoint = self.waypoints[index]
+                namedWaypoints.append(Waypoint(coordinate: coordinate, name: waypoint.name ?? json["name"] as? String))
             }
         } else {
             namedWaypoints = self.waypoints


### PR DESCRIPTION
Addresses errors like:

* 'map' produces '[T]', not the expected contextual result type 'Waypoint'
* Closure tuple parameter '(offset: Int, element: Bool)' does not support destructuring with implicit parameters