### PR TITLE
Rename includeExitRoundaboutManeuver to includesExitRoundaboutManeuver

### DIFF
--- a/MapboxDirections/MBRouteOptions.swift
+++ b/MapboxDirections/MBRouteOptions.swift
@@ -180,7 +180,7 @@ open class RouteOptions: NSObject, NSSecureCoding {
         }
         self.attributeOptions = attributeOptions
         
-        includeExitRoundaboutManeuver = decoder.decodeBool(forKey: "includeExitRoundaboutManeuver")
+        includesExitRoundaboutManeuver = decoder.decodeBool(forKey: "includesExitRoundaboutManeuver")
     }
     
     open static var supportsSecureCoding = true
@@ -194,7 +194,7 @@ open class RouteOptions: NSObject, NSSecureCoding {
         coder.encode(shapeFormat.description, forKey: "shapeFormat")
         coder.encode(routeShapeResolution.description, forKey: "routeShapeResolution")
         coder.encode(attributeOptions.description, forKey: "attributeOptions")
-        coder.encode(includeExitRoundaboutManeuver, forKey: "includeExitRoundaboutManeuver")
+        coder.encode(includesExitRoundaboutManeuver, forKey: "includesExitRoundaboutManeuver")
     }
     
     // MARK: Specifying the Path of the Route
@@ -301,7 +301,7 @@ open class RouteOptions: NSObject, NSSecureCoding {
      
      If this option is set to `true`, a route that traverses a roundabout includes both a `ManeuverType.takeRoundabout` step and a `ManeuverType.exitRoundabout` step; likewise, a route that traverses a large, named roundabout includes both a `ManeuverType.takeRotary` step and a `ManeuverType.exitRotary` step. Otherwise, it only includes a `ManeuverType.takeRoundabout` or `ManeuverType.takeRotary` step. This option is set to `false` by default.
      */
-    open var includeExitRoundaboutManeuver = false
+    open var includesExitRoundaboutManeuver = false
     
     /**
      An array of URL parameters to include in the request URL.
@@ -313,7 +313,7 @@ open class RouteOptions: NSObject, NSSecureCoding {
             URLQueryItem(name: "overview", value: String(describing: routeShapeResolution)),
             URLQueryItem(name: "steps", value: String(includesSteps)),
             URLQueryItem(name: "continue_straight", value: String(!allowsUTurnAtWaypoint)),
-            URLQueryItem(name: "roundabout_exit", value: String(includeExitRoundaboutManeuver)),
+            URLQueryItem(name: "roundabout_exit", value: String(includesExitRoundaboutManeuver)),
         ]
         
         // Include headings and heading accuracies if any waypoint has a nonnegative heading.

--- a/MapboxDirections/MBRouteStep.swift
+++ b/MapboxDirections/MBRouteStep.swift
@@ -183,7 +183,7 @@ public enum ManeuverType: Int, CustomStringConvertible {
      
      The step has no name, but the exit name is the name of the road to take to exit the roundabout. The exit index indicates the number of roundabout exits up to and including the exit to take.
      
-     If `RouteOptions.includeExitRoundaboutManeuver` is set to `true`, this step is followed by an `.exitRoundabout` maneuver. Otherwise, this step represents the entire roundabout maneuver, from the entrance to the exit.
+     If `RouteOptions.includesExitRoundaboutManeuver` is set to `true`, this step is followed by an `.exitRoundabout` maneuver. Otherwise, this step represents the entire roundabout maneuver, from the entrance to the exit.
      */
     case takeRoundabout
     
@@ -192,7 +192,7 @@ public enum ManeuverType: Int, CustomStringConvertible {
      
      The step’s name is the name of the roundabout. The exit name is the name of the road to take to exit the roundabout. The exit index indicates the number of rotary exits up to and including the exit that the user must take.
      
-      If `RouteOptions.includeExitRoundaboutManeuver` is set to `true`, this step is followed by an `.exitRotary` maneuver. Otherwise, this step represents the entire roundabout maneuver, from the entrance to the exit.
+      If `RouteOptions.includesExitRoundaboutManeuver` is set to `true`, this step is followed by an `.exitRotary` maneuver. Otherwise, this step represents the entire roundabout maneuver, from the entrance to the exit.
      */
     case takeRotary
     
@@ -206,14 +206,14 @@ public enum ManeuverType: Int, CustomStringConvertible {
     /**
      The step requires the user to exit a roundabout (traffic circle or rotary).
      
-     This maneuver type follows a `.takeRoundabout` maneuver. It is only used when `RouteOptions.includeExitRoundaboutManeuver` is set to true.
+     This maneuver type follows a `.takeRoundabout` maneuver. It is only used when `RouteOptions.includesExitRoundaboutManeuver` is set to true.
      */
     case exitRoundabout
     
     /**
      The step requires the user to exit a large, named roundabout (traffic circle or rotary).
      
-     This maneuver type follows a `.takeRotary` maneuver. It is only used when `RouteOptions.includeExitRoundaboutManeuver` is set to true.
+     This maneuver type follows a `.takeRotary` maneuver. It is only used when `RouteOptions.includesExitRoundaboutManeuver` is set to true.
      */
     case exitRotary
     


### PR DESCRIPTION
The new name makes it sound more like a property than an action method, which is important in Objective-C. It’s also consistent with `includesSteps`.

/cc @bsudekum