### PR TITLE
Pin polyline to v4.1.1

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -1,1 +1,1 @@
-github "raphaelmor/Polyline" ~> 4.1.1
+github "raphaelmor/Polyline" == 4.1.1

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,3 +1,3 @@
-binary "https://www.mapbox.com/ios-sdk/Mapbox-iOS-SDK.json" "3.5.4"
+binary "https://www.mapbox.com/ios-sdk/Mapbox-iOS-SDK.json" "3.6.4"
 github "AliSoftware/OHHTTPStubs" "6.0.0"
 github "raphaelmor/Polyline" "v4.1.1"

--- a/MapboxDirections.swift.podspec
+++ b/MapboxDirections.swift.podspec
@@ -44,6 +44,6 @@ Pod::Spec.new do |s|
   s.requires_arc = true
   s.module_name = "MapboxDirections"
 
-  s.dependency "Polyline", "~> 4.1.1"
+  s.dependency "Polyline", "4.1.1"
 
 end

--- a/MapboxDirections.swift.podspec
+++ b/MapboxDirections.swift.podspec
@@ -44,6 +44,6 @@ Pod::Spec.new do |s|
   s.requires_arc = true
   s.module_name = "MapboxDirections"
 
-  s.dependency "Polyline", "~> 4.1.0"
+  s.dependency "Polyline", "~> 4.1.1"
 
 end


### PR DESCRIPTION
Carthage has an issue where `~> 4.1.1` resolves to v4.2.0 when running carthage update.

This pins it to the last swift 3 version.

/cc @1ec5 