### PR TITLE
Properly decode locale optional

### DIFF
--- a/MapboxDirections/MBRouteOptions.swift
+++ b/MapboxDirections/MBRouteOptions.swift
@@ -225,9 +225,7 @@ open class RouteOptions: NSObject, NSSecureCoding {
 
         includesExitRoundaboutManeuver = decoder.decodeBool(forKey: "includesExitRoundaboutManeuver")
         
-        if let locale = decoder.decodeObject(of: NSLocale.self, forKey: "locale") as Locale? {
-            self.locale = locale
-        }
+        locale = decoder.decodeObject(of: NSLocale.self, forKey: "locale") as Locale?
 
         includesVoiceInstructions = decoder.decodeBool(forKey: "includeVoiceInstructions")
     }

--- a/MapboxDirections/MBRouteOptions.swift
+++ b/MapboxDirections/MBRouteOptions.swift
@@ -225,10 +225,9 @@ open class RouteOptions: NSObject, NSSecureCoding {
 
         includesExitRoundaboutManeuver = decoder.decodeBool(forKey: "includesExitRoundaboutManeuver")
         
-        guard let locale = decoder.decodeObject(of: NSLocale.self, forKey: "locale") as Locale? else {
-            return nil
+        if let locale = decoder.decodeObject(of: NSLocale.self, forKey: "locale") as Locale? {
+            self.locale = locale
         }
-        self.locale = locale
 
         includesVoiceInstructions = decoder.decodeBool(forKey: "includeVoiceInstructions")
     }


### PR DESCRIPTION
Followup to https://github.com/mapbox/MapboxDirections.swift/pull/176

Locale is optional so we should only be setting this optional value if it's set in the first place. I'm currently running into issues where route created without a `locale` are not conforming to `Route`.

/cc @1ec5 @frederoni 