### PR TITLE
Update expected travel time documentation

### DIFF
--- a/MapboxDirections/MBRoute.swift
+++ b/MapboxDirections/MBRoute.swift
@@ -154,7 +154,9 @@ open class Route: NSObject, NSSecureCoding {
     /**
      The route’s expected travel time, measured in seconds.
      
-     The value of this property reflects the time it takes to traverse the entire route under ideal conditions. It is the sum of the `expectedTravelTime` properties of the route’s legs. You should not assume that the user would travel along the route at a fixed speed. The actual travel time may vary based on the weather, traffic conditions, road construction, and other variables. If the route makes use of a ferry or train, the actual travel time may additionally be subject to the schedules of those services.
+     The value of this property reflects the time it takes to traverse the entire route. It is the sum of the `expectedTravelTime` properties of the route’s legs. If the route was calculated using the `MBDirectionsProfileIdentifierAutomobileAvoidingTraffic` profile, this property reflects current traffic conditions at the time of the request, not necessarily the traffic conditions at the time the user would begin the route. For other profiles, this property reflects travel time under ideal conditions and does not account for traffic congestion. If the route makes use of a ferry or train, the actual travel time may additionally be subject to the schedules of those services.
+     
+     Do not assume that the user would travel along the route at a fixed speed. For more granular travel times, use the `RouteLeg.expectedTravelTime` or `RouteStep.expectedTravelTime`. For even more granularity, specify the `AttributeOptions.expectedTravelTime` option and use the `RouteLeg.expectedSegmentTravelTimes` property.
      */
     open let expectedTravelTime: TimeInterval
     

--- a/MapboxDirections/MBRouteLeg.swift
+++ b/MapboxDirections/MBRouteLeg.swift
@@ -211,7 +211,9 @@ open class RouteLeg: NSObject, NSSecureCoding {
     /**
      The route leg’s expected travel time, measured in seconds.
      
-     The value of this property reflects the time it takes to traverse the route leg under ideal conditions. You should not assume that the user would travel along the route leg at a fixed speed. The actual travel time may vary based on the weather, traffic conditions, road construction, and other variables. If the route leg makes use of a ferry or train, the actual travel time may additionally be subject to the schedules of those services.
+     The value of this property reflects the time it takes to traverse the route leg. If the route was calculated using the `MBDirectionsProfileIdentifierAutomobileAvoidingTraffic` profile, this property reflects current traffic conditions at the time of the request, not necessarily the traffic conditions at the time the user would begin this leg. For other profiles, this property reflects travel time under ideal conditions and does not account for traffic congestion. If the leg makes use of a ferry or train, the actual travel time may additionally be subject to the schedules of those services.
+     
+     Do not assume that the user would travel along the leg at a fixed speed. For the expected travel time on each individual segment along the leg, use the `RouteStep.expectedTravelTimes` property. For more granularity, specify the `AttributeOptions.expectedTravelTime` option and use the `expectedSegmentTravelTimes` property.
      */
     open let expectedTravelTime: TimeInterval
     

--- a/MapboxDirections/MBRouteStep.swift
+++ b/MapboxDirections/MBRouteStep.swift
@@ -822,7 +822,9 @@ open class RouteStep: NSObject, NSSecureCoding {
     /**
      The step’s expected travel time, measured in seconds.
      
-     The value of this property reflects the time it takes to go from this step’s maneuver location to the next step’s maneuver location under ideal conditions. You should not assume that the user would travel along the step at a fixed speed. The actual travel time may vary based on the weather, traffic conditions, road construction, and other variables. If the step makes use of a ferry or train, the actual travel time may additionally be subject to the schedules of those services.
+     The value of this property reflects the time it takes to go from this step’s maneuver location to the next step’s maneuver location. If the route was calculated using the `MBDirectionsProfileIdentifierAutomobileAvoidingTraffic` profile, this property reflects current traffic conditions at the time of the request, not necessarily the traffic conditions at the time the user would begin this step. For other profiles, this property reflects travel time under ideal conditions and does not account for traffic congestion. If the step makes use of a ferry or train, the actual travel time may additionally be subject to the schedules of those services.
+     
+     Do not assume that the user would travel along the step at a fixed speed. For the expected travel time on each individual segment along the leg, specify the `AttributeOptions.expectedTravelTime` option and use the `RouteLeg.expectedSegmentTravelTimes` property.
      */
     open let expectedTravelTime: TimeInterval
     


### PR DESCRIPTION
This library’s documentation for the `RouteStep.expectedTravelTime` property hasn’t been updated since we added support for the `MBDirectionsProfileIdentifierAutomobileAvoidingTraffic` profile, which does cause the property to reflect traffic conditions.

/cc @bsudekum @ericrwolfe @AnnaStaley @frederoni