### PR TITLE
Adding support for `NSCopying` protocol.

### DIFF
--- a/MapboxDirections/MBRouteOptions.swift
+++ b/MapboxDirections/MBRouteOptions.swift
@@ -149,7 +149,7 @@ public enum MeasurementSystem: UInt, CustomStringConvertible {
  Pass an instance of this class into the `Directions.calculate(_:completionHandler:)` method.
  */
 @objc(MBRouteOptions)
-open class RouteOptions: NSObject, NSSecureCoding {
+open class RouteOptions: NSObject, NSSecureCoding, NSCopying{
     // MARK: Creating a Route Options Object
 
     /**
@@ -457,6 +457,26 @@ open class RouteOptions: NSObject, NSSecureCoding {
             Route(json: $0, waypoints: namedWaypoints, routeOptions: self)
         }
         return (waypoints, routes)
+    }
+    
+    // MARK: NSCopying
+    /**
+     Returns a copy of the object.
+     - parameter zone: an NSZone to use in the copy operation.
+     - returns: A copy of the object.
+     */
+    open func copy(with zone: NSZone? = nil) -> Any {
+        let copy = RouteOptions(waypoints: waypoints, profileIdentifier: profileIdentifier)
+        copy.allowsUTurnAtWaypoint = allowsUTurnAtWaypoint
+        copy.includesAlternativeRoutes = includesAlternativeRoutes
+        copy.includesSteps = includesSteps
+        copy.shapeFormat = shapeFormat
+        copy.routeShapeResolution = routeShapeResolution
+        copy.attributeOptions = attributeOptions
+        copy.includesExitRoundaboutManeuver = includesExitRoundaboutManeuver
+        copy.locale = locale
+        copy.includesSpokenInstructions = includesSpokenInstructions
+        return copy
     }
 }
 

--- a/MapboxDirections/MBRouteOptions.swift
+++ b/MapboxDirections/MBRouteOptions.swift
@@ -460,11 +460,6 @@ open class RouteOptions: NSObject, NSSecureCoding, NSCopying{
     }
     
     // MARK: NSCopying
-    /**
-     Returns a copy of the object.
-     - parameter zone: an NSZone to use in the copy operation.
-     - returns: A copy of the object.
-     */
     open func copy(with zone: NSZone? = nil) -> Any {
         let copy = RouteOptions(waypoints: waypoints, profileIdentifier: profileIdentifier)
         copy.allowsUTurnAtWaypoint = allowsUTurnAtWaypoint
@@ -477,6 +472,28 @@ open class RouteOptions: NSObject, NSSecureCoding, NSCopying{
         copy.locale = locale
         copy.includesSpokenInstructions = includesSpokenInstructions
         return copy
+    }
+    
+    //MARK: - OBJ-C Equality
+    open override func isEqual(_ object: Any?) -> Bool {
+        guard let opts = object as? RouteOptions else { return false }
+        return isEqual(to: opts)
+    }
+    
+    @objc(isEqualToRouteOptions:)
+    open func isEqual(to routeOptions: RouteOptions?) -> Bool {
+        guard let other = routeOptions else { return false }
+        guard waypoints == other.waypoints,
+            profileIdentifier == other.profileIdentifier,
+            allowsUTurnAtWaypoint == other.allowsUTurnAtWaypoint,
+            includesSteps == other.includesSteps,
+            shapeFormat == other.shapeFormat,
+            routeShapeResolution == other.routeShapeResolution,
+            attributeOptions == other.attributeOptions,
+            includesExitRoundaboutManeuver == other.includesExitRoundaboutManeuver,
+            locale == other.locale,
+            includesSpokenInstructions == other.includesSpokenInstructions else { return false }
+        return true
     }
 }
 

--- a/MapboxDirections/MBRouteOptions.swift
+++ b/MapboxDirections/MBRouteOptions.swift
@@ -228,6 +228,11 @@ open class RouteOptions: NSObject, NSSecureCoding, NSCopying{
         locale = decoder.decodeObject(of: NSLocale.self, forKey: "locale") as Locale?
 
         includesSpokenInstructions = decoder.decodeBool(forKey: "includesSpokenInstructions")
+        
+        guard let distanceMeasurementSystem = MeasurementSystem(description: decoder.decodeObject(of: NSString.self, forKey: "distanceMeasurementSystem") as String? ?? "") else {
+            return nil
+        }
+        self.distanceMeasurementSystem = distanceMeasurementSystem
     }
 
     open static var supportsSecureCoding = true
@@ -244,6 +249,7 @@ open class RouteOptions: NSObject, NSSecureCoding, NSCopying{
         coder.encode(includesExitRoundaboutManeuver, forKey: "includesExitRoundaboutManeuver")
         coder.encode(locale, forKey: "locale")
         coder.encode(includesSpokenInstructions, forKey: "includesSpokenInstructions")
+        coder.encode(distanceMeasurementSystem.description, forKey: "distanceMeasurementSystem")
     }
 
     // MARK: Specifying the Path of the Route
@@ -471,6 +477,7 @@ open class RouteOptions: NSObject, NSSecureCoding, NSCopying{
         copy.includesExitRoundaboutManeuver = includesExitRoundaboutManeuver
         copy.locale = locale
         copy.includesSpokenInstructions = includesSpokenInstructions
+        copy.distanceMeasurementSystem = distanceMeasurementSystem
         return copy
     }
     
@@ -492,7 +499,8 @@ open class RouteOptions: NSObject, NSSecureCoding, NSCopying{
             attributeOptions == other.attributeOptions,
             includesExitRoundaboutManeuver == other.includesExitRoundaboutManeuver,
             locale == other.locale,
-            includesSpokenInstructions == other.includesSpokenInstructions else { return false }
+            includesSpokenInstructions == other.includesSpokenInstructions,
+            distanceMeasurementSystem == other.distanceMeasurementSystem else { return false }
         return true
     }
 }

--- a/MapboxDirectionsTests/RouteOptionsTests.swift
+++ b/MapboxDirectionsTests/RouteOptionsTests.swift
@@ -3,15 +3,8 @@ import XCTest
 
 class RouteOptionsTests: XCTestCase {
     func testCoding() {
-        let coordinates = [
-            CLLocationCoordinate2D(latitude: 52.5109, longitude: 13.4301),
-            CLLocationCoordinate2D(latitude: 52.5080, longitude: 13.4265),
-            CLLocationCoordinate2D(latitude: 52.5021, longitude: 13.4316),
-        ]
-        
-        let options = RouteOptions(coordinates: coordinates, profileIdentifier: .automobileAvoidingTraffic)
-        options.locale = Locale(identifier: "en")
-        
+ 
+        let options = RouteOptions.testInstance
         let encodedData = NSMutableData()
         let keyedArchiver = NSKeyedArchiver(forWritingWith: encodedData)
         keyedArchiver.requiresSecureCoding = true
@@ -25,6 +18,7 @@ class RouteOptionsTests: XCTestCase {
         
         XCTAssertNotNil(unarchivedOptions)
         
+        let coordinates = RouteOptions.testCoordinates
         let unarchivedWaypoints = unarchivedOptions.waypoints
         XCTAssertEqual(unarchivedWaypoints.count, coordinates.count)
         XCTAssertEqual(unarchivedWaypoints[0].coordinate.latitude, coordinates[0].latitude)
@@ -38,5 +32,35 @@ class RouteOptionsTests: XCTestCase {
         XCTAssertEqual(unarchivedOptions.locale, options.locale)
         XCTAssertEqual(unarchivedOptions.includesSpokenInstructions, options.includesSpokenInstructions)
         XCTAssertEqual(unarchivedOptions.distanceMeasurementSystem, options.distanceMeasurementSystem)
+    }
+    func testCopying() {
+        let testInstance = RouteOptions.testInstance
+        guard let copy = testInstance.copy() as? RouteOptions else { return XCTFail("RouteOptions copy method should an object of same type") }
+        XCTAssertNotNil(copy, "Copy should not be nil.")
+        XCTAssertTrue(testInstance == copy, "Test Instance and copy should be semantically equivalent.")
+        XCTAssertFalse(testInstance === copy, "Test Instance and copy should not be identical.")
+        
+    }
+}
+
+private extension RouteOptions {
+    static var testCoordinates: [CLLocationCoordinate2D] {
+        return [
+            CLLocationCoordinate2D(latitude: 52.5109, longitude: 13.4301),
+            CLLocationCoordinate2D(latitude: 52.5080, longitude: 13.4265),
+            CLLocationCoordinate2D(latitude: 52.5021, longitude: 13.4316),
+        ]
+    }
+    static var testInstance: RouteOptions {
+        let opts = RouteOptions(coordinates: self.testCoordinates, profileIdentifier: .automobileAvoidingTraffic)
+        opts.locale = Locale(identifier: "en_US")
+        opts.allowsUTurnAtWaypoint = true
+        opts.shapeFormat = .polyline
+        opts.routeShapeResolution = .full
+        opts.attributeOptions = [.congestionLevel]
+        opts.includesExitRoundaboutManeuver = true
+        opts.includesSpokenInstructions = true
+        
+        return opts
     }
 }

--- a/MapboxDirectionsTests/RouteOptionsTests.swift
+++ b/MapboxDirectionsTests/RouteOptionsTests.swift
@@ -60,6 +60,7 @@ private extension RouteOptions {
         opts.attributeOptions = [.congestionLevel]
         opts.includesExitRoundaboutManeuver = true
         opts.includesSpokenInstructions = true
+        opts.distanceMeasurementSystem = .metric
         
         return opts
     }


### PR DESCRIPTION
What it says on the box. Making `RouteObject` conform to `NSCopying`. Needed for mapbox/mapbox-navigation-ios#806.

/cc @1ec5 @bsudekum