### PR TITLE
QuickFix: RouteOptions.init(coder: NSCoder)

### DIFF
--- a/MapboxDirections/MBRouteOptions.swift
+++ b/MapboxDirections/MBRouteOptions.swift
@@ -231,10 +231,9 @@ open class RouteOptions: NSObject, NSSecureCoding, NSCopying{
 
         includesSpokenInstructions = decoder.decodeBool(forKey: "includesSpokenInstructions")
         
-        guard let distanceMeasurementSystem = MeasurementSystem(description: decoder.decodeObject(of: NSString.self, forKey: "distanceMeasurementSystem") as String? ?? "") else {
-            return nil
+        if let distanceMeasurementSystem = MeasurementSystem(description: decoder.decodeObject(of: NSString.self, forKey: "distanceMeasurementSystem") as String? ?? "") {
+            self.distanceMeasurementSystem = distanceMeasurementSystem
         }
-        self.distanceMeasurementSystem = distanceMeasurementSystem
     }
 
     open static var supportsSecureCoding = true


### PR DESCRIPTION
*  Fixing issue where a missing (or invalid) value for `distanceMeasurementSystem` keypath would cause initializer to fail entirely.