### PR TITLE
Allow Directions.calculate(_:completionHandler:) result to be implictly discarded

### DIFF
--- a/Directions Example/ViewController.m
+++ b/Directions Example/ViewController.m
@@ -36,7 +36,7 @@ NSString * const MapboxAccessToken = @"<# your Mapbox access token #>";
     MBRouteOptions *options = [[MBRouteOptions alloc] initWithWaypoints:waypoints profileIdentifier:nil];
     options.includesSteps = YES;
     
-    (void)[[[MBDirections alloc] initWithAccessToken:MapboxAccessToken] calculateDirectionsWithOptions:options completionHandler:^(NSArray<MBWaypoint *> * _Nullable waypoints, NSArray<MBRoute *> * _Nullable routes, NSError * _Nullable error) {
+    [[[MBDirections alloc] initWithAccessToken:MapboxAccessToken] calculateDirectionsWithOptions:options completionHandler:^(NSArray<MBWaypoint *> * _Nullable waypoints, NSArray<MBRoute *> * _Nullable routes, NSError * _Nullable error) {
         if (error) {
             NSLog(@"Error calculating directions: %@", error);
             return;

--- a/Directions Example/ViewController.swift
+++ b/Directions Example/ViewController.swift
@@ -30,7 +30,7 @@ class ViewController: UIViewController {
         ])
         options.includesSteps = true
         
-        _ = Directions(accessToken: MapboxAccessToken).calculate(options) { (waypoints, routes, error) in
+        Directions(accessToken: MapboxAccessToken).calculate(options) { (waypoints, routes, error) in
             guard error == nil else {
                 print("Error calculating directions: \(error!)")
                 return

--- a/MapboxDirections/MBDirections.swift
+++ b/MapboxDirections/MBDirections.swift
@@ -164,7 +164,7 @@ open class Directions: NSObject {
      - returns: The data task used to perform the HTTP request. If, while waiting for the completion handler to execute, you no longer want the resulting routes, cancel this task.
      */
     @objc(calculateDirectionsWithOptions:completionHandler:)
-    open func calculate(_ options: RouteOptions, completionHandler: @escaping CompletionHandler) -> URLSessionDataTask {
+    @discardableResult open func calculate(_ options: RouteOptions, completionHandler: @escaping CompletionHandler) -> URLSessionDataTask {
         let url = self.url(forCalculating: options)
         let task = dataTask(with: url, completionHandler: { (json) in
             let response = options.response(from: json)


### PR DESCRIPTION
This PR makes the practice of discarding the result of `Directions.calculate(_:completionHandler:)` a bit friendlier by annotating it as `@discardableResult`. This means that the implementer does not need to explicitly discard via `_ =` or `(void)` (or face a warning when they do not).

/cc @1ec5 @frederoni @bsudekum @captainbarbosa 