### PR TITLE
Unwrap optional roadClass

### DIFF
--- a/MapboxDirections/MBRouteOptions.swift
+++ b/MapboxDirections/MBRouteOptions.swift
@@ -440,14 +440,14 @@ open class RouteOptions: NSObject, NSSecureCoding, NSCopying{
             params.append(URLQueryItem(name: "banner_instructions", value: String(includesVisualInstructions)))
         }
         
-        if !roadClassesToAvoid.isEmpty {
+        if roadClassesToAvoid.isEmpty {
             let allRoadClasses = roadClassesToAvoid.description.components(separatedBy: ",")
             if allRoadClasses.count > 1 {
                 assert(false, "`roadClassesToAvoid` only accepts one `RoadClasses`.")
             }
-            let firstRoadClass = String(describing: allRoadClasses.first!)
-            params.append(URLQueryItem(name: "exclude", value: firstRoadClass))
-
+            if let firstRoadClass = allRoadClasses.first {
+                params.append(URLQueryItem(name: "exclude", value: String(describing: firstRoadClass)))
+            }
         }
 
         // Include headings and heading accuracies if any waypoint has a nonnegative heading.

--- a/MapboxDirections/MBRouteOptions.swift
+++ b/MapboxDirections/MBRouteOptions.swift
@@ -446,7 +446,7 @@ open class RouteOptions: NSObject, NSSecureCoding, NSCopying{
                 assert(false, "`roadClassesToAvoid` only accepts one `RoadClasses`.")
             }
             if let firstRoadClass = allRoadClasses.first {
-                params.append(URLQueryItem(name: "exclude", value: String(describing: firstRoadClass)))
+                params.append(URLQueryItem(name: "exclude", value: firstRoadClass))
             }
         }
 

--- a/MapboxDirections/MBRouteOptions.swift
+++ b/MapboxDirections/MBRouteOptions.swift
@@ -442,10 +442,10 @@ open class RouteOptions: NSObject, NSSecureCoding, NSCopying{
         
         if !roadClassesToAvoid.isEmpty {
             let allRoadClasses = roadClassesToAvoid.description.components(separatedBy: ",")
-            let firstRoadClass = String(describing: allRoadClasses.first)
             if allRoadClasses.count > 1 {
                 assert(false, "`roadClassesToAvoid` only accepts one `RoadClasses`.")
             }
+            let firstRoadClass = String(describing: allRoadClasses.first!)
             params.append(URLQueryItem(name: "exclude", value: firstRoadClass))
 
         }

--- a/MapboxDirections/MBRouteOptions.swift
+++ b/MapboxDirections/MBRouteOptions.swift
@@ -440,7 +440,7 @@ open class RouteOptions: NSObject, NSSecureCoding, NSCopying{
             params.append(URLQueryItem(name: "banner_instructions", value: String(includesVisualInstructions)))
         }
         
-        if roadClassesToAvoid.isEmpty {
+        if !roadClassesToAvoid.isEmpty {
             let allRoadClasses = roadClassesToAvoid.description.components(separatedBy: ",")
             if allRoadClasses.count > 1 {
                 assert(false, "`roadClassesToAvoid` only accepts one `RoadClasses`.")


### PR DESCRIPTION
Followup to https://github.com/mapbox/MapboxDirections.swift/pull/180

We were sending across: `\Optional(motorway)`.

/cc @1ec5 @JThramer 