### PR TITLE
Make Voice and Visual Instructions open

### DIFF
--- a/MapboxDirections/MBSpokenInstruction.swift
+++ b/MapboxDirections/MBSpokenInstruction.swift
@@ -8,7 +8,7 @@ import Foundation
  The `distanceAlongStep` property is measured from the beginning of the step associated with this object. By contrast, the `text` and `ssmlText` properties refer to the details in the following step. It is also possible for the instruction to refer to two following steps simultaneously when needed for safe navigation.
  */
 @objc(MBSpokenInstruction)
-public class SpokenInstruction: NSObject, NSSecureCoding {
+open class SpokenInstruction: NSObject, NSSecureCoding {
     
     /**
      A distance along the associated `RouteStep` at which to read the instruction aloud.
@@ -33,10 +33,18 @@ public class SpokenInstruction: NSObject, NSSecureCoding {
      */
     @objc public let ssmlText: String
     
-    internal init(json: JSONDictionary) {
-        distanceAlongStep = json["distanceAlongGeometry"] as! CLLocationDistance
-        text = json["announcement"] as! String
-        ssmlText = json["ssmlAnnouncement"] as! String
+    @objc public convenience init(json: [String: Any]) {
+        let distanceAlongStep = json["distanceAlongGeometry"] as! CLLocationDistance
+        let text = json["announcement"] as! String
+        let ssmlText = json["ssmlAnnouncement"] as! String
+
+        self.init(distanceAlongStep: distanceAlongStep, text: text, ssmlText: ssmlText)
+    }
+
+    @objc internal init(distanceAlongStep: CLLocationDistance, text: String, ssmlText: String) {
+        self.distanceAlongStep = distanceAlongStep
+        self.text = text
+        self.ssmlText = ssmlText
     }
     
     public required init?(coder decoder: NSCoder) {

--- a/MapboxDirections/MBSpokenInstruction.swift
+++ b/MapboxDirections/MBSpokenInstruction.swift
@@ -33,6 +33,9 @@ open class SpokenInstruction: NSObject, NSSecureCoding {
      */
     @objc public let ssmlText: String
     
+    /**
+     Initialize a `SpokenInStruction` from a dictionary.
+     */
     @objc public convenience init(json: [String: Any]) {
         let distanceAlongStep = json["distanceAlongGeometry"] as! CLLocationDistance
         let text = json["announcement"] as! String
@@ -41,7 +44,14 @@ open class SpokenInstruction: NSObject, NSSecureCoding {
         self.init(distanceAlongStep: distanceAlongStep, text: text, ssmlText: ssmlText)
     }
 
-    @objc internal init(distanceAlongStep: CLLocationDistance, text: String, ssmlText: String) {
+    /**
+     Initialize a `SpokenInStruction`.
+     
+     - parameter distanceAlongStep: A distance along the associated `RouteStep` at which to read the instruction aloud.
+     - parameter text: A plain-text representation of the speech-optimized instruction.
+     - parameter ssmlText: A formatted representation of the speech-optimized instruction.
+     */
+    @objc public init(distanceAlongStep: CLLocationDistance, text: String, ssmlText: String) {
         self.distanceAlongStep = distanceAlongStep
         self.text = text
         self.ssmlText = ssmlText

--- a/MapboxDirections/MBSpokenInstruction.swift
+++ b/MapboxDirections/MBSpokenInstruction.swift
@@ -34,7 +34,7 @@ open class SpokenInstruction: NSObject, NSSecureCoding {
     @objc public let ssmlText: String
     
     /**
-     Initialize a `SpokenInStruction` from a dictionary.
+     Initialize a `SpokenInstruction` from a dictionary.
      */
     @objc public convenience init(json: [String: Any]) {
         let distanceAlongStep = json["distanceAlongGeometry"] as! CLLocationDistance
@@ -45,7 +45,7 @@ open class SpokenInstruction: NSObject, NSSecureCoding {
     }
 
     /**
-     Initialize a `SpokenInStruction`.
+     Initialize a `SpokenInstruction`.
      
      - parameter distanceAlongStep: A distance along the associated `RouteStep` at which to read the instruction aloud.
      - parameter text: A plain-text representation of the speech-optimized instruction.

--- a/MapboxDirections/MBVisualInstruction.swift
+++ b/MapboxDirections/MBVisualInstruction.swift
@@ -11,12 +11,13 @@ open class VisualInstruction: NSObject, NSSecureCoding {
      :nodoc:
      Distance in meters from the beginning of the step at which the visual instruction should be visible.
      */
-    public let distanceAlongStep: CLLocationDistance
+    @objc public let distanceAlongStep: CLLocationDistance
     
     /**
+     :nodoc:
      A plain text representation of `primaryTextComponents`.
      */
-    public let primaryText: String
+    @objc public let primaryText: String
 
     /**
      :nodoc:
@@ -24,13 +25,13 @@ open class VisualInstruction: NSObject, NSSecureCoding {
      
      This is the structured representation of `primaryText`.
      */
-    public let primaryTextComponents: [VisualInstructionComponent]
-    
+    @objc public let primaryTextComponents: [VisualInstructionComponent]
     
     /**
+     :nodoc:
      A plain text representation of `secondaryTextComponents`.
      */
-    public let secondaryText: String?
+    @objc public let secondaryText: String?
     
     /**
      :nodoc:
@@ -38,27 +39,43 @@ open class VisualInstruction: NSObject, NSSecureCoding {
      
      This is the structured representation of `secondaryText`.
      */
-    public let secondaryTextComponents: [VisualInstructionComponent]?
+    @objc public let secondaryTextComponents: [VisualInstructionComponent]?
     
-    
-    init(json: JSONDictionary) {
-        distanceAlongStep = json["distanceAlongGeometry"] as! CLLocationDistance
+    /**
+     :nodoc:
+     Initialize a `VisualInstruction` from a dictionary.
+     */
+    @objc public convenience init(json: [String: Any]) {
+        let distanceAlongStep = json["distanceAlongGeometry"] as! CLLocationDistance
         
         let primaryTextComponent = json["primary"] as! JSONDictionary
-        primaryText = primaryTextComponent["text"] as! String
-        primaryTextComponents = (primaryTextComponent["components"] as! [JSONDictionary]).map {
+        let primaryText = primaryTextComponent["text"] as! String
+        let primaryTextComponents = (primaryTextComponent["components"] as! [JSONDictionary]).map {
             VisualInstructionComponent(json: $0)
         }
         
+        var secondaryText: String?
+        var secondaryTextComponents: [VisualInstructionComponent]?
         if let secondaryTextComponent = json["secondary"] as? JSONDictionary {
             secondaryText = secondaryTextComponent["text"] as? String
             secondaryTextComponents = (secondaryTextComponent["components"] as! [JSONDictionary]).map {
                 VisualInstructionComponent(json: $0)
             }
-        } else {
-            secondaryText = nil
-            secondaryTextComponents = nil
         }
+        
+        self.init(distanceAlongStep: distanceAlongStep, primaryText: primaryText, primaryTextComponents: primaryTextComponents, secondaryText: secondaryText, secondaryTextComponents: secondaryTextComponents)
+    }
+    
+    /**
+     :nodoc:
+     Initialize a `VisualInstruction`.
+     */
+    @objc public init(distanceAlongStep: CLLocationDistance, primaryText: String, primaryTextComponents: [VisualInstructionComponent], secondaryText: String?, secondaryTextComponents: [VisualInstructionComponent]?) {
+        self.distanceAlongStep = distanceAlongStep
+        self.primaryText = primaryText
+        self.primaryTextComponents = primaryTextComponents
+        self.secondaryText = secondaryText
+        self.secondaryTextComponents = secondaryTextComponents
     }
     
     public required init?(coder decoder: NSCoder) {

--- a/MapboxDirections/MBVisualInstruction.swift
+++ b/MapboxDirections/MBVisualInstruction.swift
@@ -5,7 +5,7 @@ import Foundation
  Encompasses all information necessary for creating a visual cue about a given `RouteStep`.
  */
 @objc(MBVisualInstruction)
-public class VisualInstruction: NSObject, NSSecureCoding {
+open class VisualInstruction: NSObject, NSSecureCoding {
     
     /**
      :nodoc:
@@ -41,7 +41,7 @@ public class VisualInstruction: NSObject, NSSecureCoding {
     public let secondaryTextComponents: [VisualInstructionComponent]?
     
     
-    internal init(json: JSONDictionary) {
+    init(json: JSONDictionary) {
         distanceAlongStep = json["distanceAlongGeometry"] as! CLLocationDistance
         
         let primaryTextComponent = json["primary"] as! JSONDictionary

--- a/MapboxDirections/MBVisualInstructionComponent.swift
+++ b/MapboxDirections/MBVisualInstructionComponent.swift
@@ -13,7 +13,7 @@ import Foundation
  A component of a `VisualInstruction` that represents a single run of similarly formatted text or an image with a textual fallback representation.
  */
 @objc(MBVisualInstructionComponent)
-public class VisualInstructionComponent: NSObject, NSSecureCoding {
+open class VisualInstructionComponent: NSObject, NSSecureCoding {
     
     /**
      :nodoc:
@@ -21,7 +21,7 @@ public class VisualInstructionComponent: NSObject, NSSecureCoding {
      
      Use this property if `imageURLs` is an empty dictionary or if the URLs contained in that property are not yet available.
      */
-    public let text: String?
+    @objc public let text: String?
     
     /**
      :nodoc:
@@ -29,10 +29,16 @@ public class VisualInstructionComponent: NSObject, NSSecureCoding {
  
     The URL refers to an image that uses the device’s native screen scale.
     */
-    public var imageURL: URL?
+    @objc public var imageURL: URL?
     
-    internal init(json: JSONDictionary) {
-        text = json["text"] as? String
+    /**
+     :nodoc:
+     Initialize A `VisualInstructionComponent`.
+     */
+    @objc public convenience init(json: [String: Any]) {
+        let text = json["text"] as? String
+        
+        var imageURL: URL?
         
         if let baseURL = json["imageBaseURL"] as? String {
             let scale: CGFloat
@@ -43,11 +49,22 @@ public class VisualInstructionComponent: NSObject, NSSecureCoding {
             #else
                 scale = UIScreen.main.scale
             #endif
-            self.imageURL = URL(string: "\(baseURL)@\(Int(scale))x.png")
+            imageURL = URL(string: "\(baseURL)@\(Int(scale))x.png")
         }
+        
+        self.init(text: text, imageURL: imageURL)
     }
     
-    public required init?(coder decoder: NSCoder) {
+    /**
+     :nodoc:
+     Initialize A `VisualInstructionComponent`.
+     */
+    @objc public init(text: String?, imageURL: URL?) {
+        self.text = text
+        self.imageURL = imageURL
+    }
+
+    @objc public required init?(coder decoder: NSCoder) {
         guard let text = decoder.decodeObject(of: NSString.self, forKey: "text") as String? else {
             return nil
         }


### PR DESCRIPTION
This PR aims to make the classes `VisualInstruction` et al and `SpokenInstruction` open and provide public initializers to make testing easier.

Also added a few missing `@objc`.

/cc @mapbox/navigation-ios 