### PR TITLE
Add isDelimiter to VisualInstructionComponent

### DIFF
--- a/MapboxDirections.xcodeproj/project.pbxproj
+++ b/MapboxDirections.xcodeproj/project.pbxproj
@@ -55,6 +55,9 @@
 		C558C58F1E94196300617B37 /* MBAttribute.h in Headers */ = {isa = PBXBuildFile; fileRef = C558C58B1E94181A00617B37 /* MBAttribute.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		C55FB44B1F6AEBF6006BD1E9 /* MBSpokenInstruction.swift in Sources */ = {isa = PBXBuildFile; fileRef = C55FB44A1F6AEBF6006BD1E9 /* MBSpokenInstruction.swift */; };
 		C56516841FE1A2DD00A0AD18 /* MBVisualInstructionType.swift in Sources */ = {isa = PBXBuildFile; fileRef = C56516831FE1A2DD00A0AD18 /* MBVisualInstructionType.swift */; };
+		C56516851FE1AB8F00A0AD18 /* MBVisualInstructionType.swift in Sources */ = {isa = PBXBuildFile; fileRef = C56516831FE1A2DD00A0AD18 /* MBVisualInstructionType.swift */; };
+		C56516861FE1AB9000A0AD18 /* MBVisualInstructionType.swift in Sources */ = {isa = PBXBuildFile; fileRef = C56516831FE1A2DD00A0AD18 /* MBVisualInstructionType.swift */; };
+		C56516871FE1AB9100A0AD18 /* MBVisualInstructionType.swift in Sources */ = {isa = PBXBuildFile; fileRef = C56516831FE1A2DD00A0AD18 /* MBVisualInstructionType.swift */; };
 		C57B2E961DB8171300E9123A /* MBLaneIndication.h in Headers */ = {isa = PBXBuildFile; fileRef = C57B2E951DB8171300E9123A /* MBLaneIndication.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		C57B2E971DB8171300E9123A /* MBLaneIndication.h in Headers */ = {isa = PBXBuildFile; fileRef = C57B2E951DB8171300E9123A /* MBLaneIndication.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		C57B2E981DB8171300E9123A /* MBLaneIndication.h in Headers */ = {isa = PBXBuildFile; fileRef = C57B2E951DB8171300E9123A /* MBLaneIndication.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -1012,6 +1015,7 @@
 				C52CE38F1F6AF63C0069963D /* MBSpokenInstruction.swift in Sources */,
 				C58EA7AB1E9D7F73008F98CE /* MBCongestion.swift in Sources */,
 				8D381B6B1FDB3D8A008D5A58 /* String.swift in Sources */,
+				C56516851FE1AB8F00A0AD18 /* MBVisualInstructionType.swift in Sources */,
 				C547EC691DB59F8F009817F3 /* MBLane.swift in Sources */,
 				DA1A10C71D00F969009F82FA /* MBDirections.swift in Sources */,
 			);
@@ -1052,6 +1056,7 @@
 				C52CE3901F6AF63D0069963D /* MBSpokenInstruction.swift in Sources */,
 				C58EA7AC1E9D7F74008F98CE /* MBCongestion.swift in Sources */,
 				8D381B6C1FDB3D8B008D5A58 /* String.swift in Sources */,
+				C56516861FE1AB9000A0AD18 /* MBVisualInstructionType.swift in Sources */,
 				C547EC6A1DB59F90009817F3 /* MBLane.swift in Sources */,
 				DA1A10ED1D010247009F82FA /* MBDirections.swift in Sources */,
 			);
@@ -1092,6 +1097,7 @@
 				C52CE3911F6AF63E0069963D /* MBSpokenInstruction.swift in Sources */,
 				C58EA7AD1E9D7F75008F98CE /* MBCongestion.swift in Sources */,
 				8D381B6D1FDB3D8B008D5A58 /* String.swift in Sources */,
+				C56516871FE1AB9100A0AD18 /* MBVisualInstructionType.swift in Sources */,
 				C547EC6B1DB59F91009817F3 /* MBLane.swift in Sources */,
 				DA1A11041D0103A3009F82FA /* MBDirections.swift in Sources */,
 			);

--- a/MapboxDirections.xcodeproj/project.pbxproj
+++ b/MapboxDirections.xcodeproj/project.pbxproj
@@ -216,7 +216,7 @@
 		C52CE3921F6AF6E70069963D /* IntructionsTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = IntructionsTests.swift; sourceTree = "<group>"; };
 		C558C58B1E94181A00617B37 /* MBAttribute.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MBAttribute.h; sourceTree = "<group>"; };
 		C55FB44A1F6AEBF6006BD1E9 /* MBSpokenInstruction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MBSpokenInstruction.swift; sourceTree = "<group>"; };
-		C56516831FE1A2DD00A0AD18 /* MBVisualInstructionType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MBVisualInstructionType.swift; sourceTree = "<group>"; };
+		C56516831FE1A2DD00A0AD18 /* MBVisualInstructionType.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MBVisualInstructionType.swift; sourceTree = "<group>"; };
 		C57B2E951DB8171300E9123A /* MBLaneIndication.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MBLaneIndication.h; sourceTree = "<group>"; };
 		C57D55001DB5669600B94B74 /* MBIntersection.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MBIntersection.swift; sourceTree = "<group>"; };
 		C57D55071DB58C0200B94B74 /* MBLane.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MBLane.swift; sourceTree = "<group>"; };

--- a/MapboxDirections.xcodeproj/project.pbxproj
+++ b/MapboxDirections.xcodeproj/project.pbxproj
@@ -54,6 +54,7 @@
 		C558C58E1E94196200617B37 /* MBAttribute.h in Headers */ = {isa = PBXBuildFile; fileRef = C558C58B1E94181A00617B37 /* MBAttribute.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		C558C58F1E94196300617B37 /* MBAttribute.h in Headers */ = {isa = PBXBuildFile; fileRef = C558C58B1E94181A00617B37 /* MBAttribute.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		C55FB44B1F6AEBF6006BD1E9 /* MBSpokenInstruction.swift in Sources */ = {isa = PBXBuildFile; fileRef = C55FB44A1F6AEBF6006BD1E9 /* MBSpokenInstruction.swift */; };
+		C56516841FE1A2DD00A0AD18 /* MBVisualInstructionType.swift in Sources */ = {isa = PBXBuildFile; fileRef = C56516831FE1A2DD00A0AD18 /* MBVisualInstructionType.swift */; };
 		C57B2E961DB8171300E9123A /* MBLaneIndication.h in Headers */ = {isa = PBXBuildFile; fileRef = C57B2E951DB8171300E9123A /* MBLaneIndication.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		C57B2E971DB8171300E9123A /* MBLaneIndication.h in Headers */ = {isa = PBXBuildFile; fileRef = C57B2E951DB8171300E9123A /* MBLaneIndication.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		C57B2E981DB8171300E9123A /* MBLaneIndication.h in Headers */ = {isa = PBXBuildFile; fileRef = C57B2E951DB8171300E9123A /* MBLaneIndication.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -212,6 +213,7 @@
 		C52CE3921F6AF6E70069963D /* IntructionsTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = IntructionsTests.swift; sourceTree = "<group>"; };
 		C558C58B1E94181A00617B37 /* MBAttribute.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MBAttribute.h; sourceTree = "<group>"; };
 		C55FB44A1F6AEBF6006BD1E9 /* MBSpokenInstruction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MBSpokenInstruction.swift; sourceTree = "<group>"; };
+		C56516831FE1A2DD00A0AD18 /* MBVisualInstructionType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MBVisualInstructionType.swift; sourceTree = "<group>"; };
 		C57B2E951DB8171300E9123A /* MBLaneIndication.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MBLaneIndication.h; sourceTree = "<group>"; };
 		C57D55001DB5669600B94B74 /* MBIntersection.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MBIntersection.swift; sourceTree = "<group>"; };
 		C57D55071DB58C0200B94B74 /* MBLane.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MBLane.swift; sourceTree = "<group>"; };
@@ -419,6 +421,7 @@
 				C55FB44A1F6AEBF6006BD1E9 /* MBSpokenInstruction.swift */,
 				C52552B81FA15D5900B1545C /* MBVisualInstruction.swift */,
 				C52552BF1FA1628A00B1545C /* MBVisualInstructionComponent.swift */,
+				C56516831FE1A2DD00A0AD18 /* MBVisualInstructionType.swift */,
 			);
 			path = MapboxDirections;
 			sourceTree = "<group>";
@@ -1113,6 +1116,7 @@
 				C55FB44B1F6AEBF6006BD1E9 /* MBSpokenInstruction.swift in Sources */,
 				C58EA7AA1E9D7EAD008F98CE /* MBCongestion.swift in Sources */,
 				8D381B6A1FDB101F008D5A58 /* String.swift in Sources */,
+				C56516841FE1A2DD00A0AD18 /* MBVisualInstructionType.swift in Sources */,
 				C57D55011DB5669600B94B74 /* MBIntersection.swift in Sources */,
 				DA2E03E91CB0E0B000D1269A /* MBRouteStep.swift in Sources */,
 			);

--- a/MapboxDirections/MBVisualInstructionComponent.swift
+++ b/MapboxDirections/MBVisualInstructionComponent.swift
@@ -45,7 +45,7 @@ open class VisualInstructionComponent: NSObject, NSSecureCoding {
     @objc public convenience init(json: [String: Any]) {
         let text = json["text"] as? String
         var type: VisualInstructionComponentType?
-        if delimiter = json["delimiter"] as? Bool {
+        if let _ = json["delimiter"] as? Bool {
             type = .delimiter
         } else {
             type = .destination

--- a/MapboxDirections/MBVisualInstructionComponent.swift
+++ b/MapboxDirections/MBVisualInstructionComponent.swift
@@ -34,9 +34,9 @@ open class VisualInstructionComponent: NSObject, NSSecureCoding {
     
     /**
      :nodoc:
-     `Bool` whether the `VisualInstructionComponent` should be visualized as a delimiter between two text components.
+     The type of the `VisualInstructionComponent`. Used for influencing how the compomenent is rendered.
      */
-    @objc public var type: VisualCompomentType
+    @objc public var type: VisualInstructionComponentType
     
     /**
      :nodoc:
@@ -44,8 +44,8 @@ open class VisualInstructionComponent: NSObject, NSSecureCoding {
      */
     @objc public convenience init(json: [String: Any]) {
         let text = json["text"] as? String
-        var type: VisualCompomentType?
-        if let delimiter = json["delimiter"] as? String, VisualCompomentType(description: delimiter) == .delimiter {
+        var type: VisualInstructionComponentType?
+        if delimiter = json["delimiter"] as? Bool {
             type = .delimiter
         } else {
             type = .destination
@@ -71,7 +71,7 @@ open class VisualInstructionComponent: NSObject, NSSecureCoding {
      :nodoc:
      Initialize A `VisualInstructionComponent`.
      */
-    @objc public init(text: String?, imageURL: URL?, type: VisualCompomentType) {
+    @objc public init(text: String?, imageURL: URL?, type: VisualInstructionComponentType) {
         self.text = text
         self.imageURL = imageURL
         self.type = type
@@ -88,7 +88,7 @@ open class VisualInstructionComponent: NSObject, NSSecureCoding {
         }
         self.imageURL = imageURL
         
-        guard let typeString = decoder.decodeObject(of: NSString.self, forKey: "type") as String?, let type = VisualCompomentType(description: typeString) else {
+        guard let typeString = decoder.decodeObject(of: NSString.self, forKey: "type") as String?, let type = VisualInstructionComponentType(description: typeString) else {
                 return nil
         }
         self.type = type
@@ -100,45 +100,5 @@ open class VisualInstructionComponent: NSObject, NSSecureCoding {
         coder.encode(text, forKey: "text")
         coder.encode(imageURL, forKey: "imageURL")
         coder.encode(type, forKey: "type")
-    }
-}
-
-
-/**
- `VisualCompomentType` describes the `text` type.
- */
-@objc(MBVisualComponentType)
-public enum VisualCompomentType: Int, CustomStringConvertible {
-
-    /**
-     Text is a delimiter.
-     */
-    case delimiter
-    
-    /**
-     Text is a way name.
-     */
-    case destination
-    
-    public init?(description: String) {
-        let level: VisualCompomentType
-        switch description {
-        case "delimiter":
-            level = .delimiter
-        case "destination":
-            level = .destination
-        default:
-            return nil
-        }
-        self.init(rawValue: level.rawValue)
-    }
-    
-    public var description: String {
-        switch self {
-        case .delimiter:
-            return "delimiter"
-        case .destination:
-            return "destination"
-        }
     }
 }

--- a/MapboxDirections/MBVisualInstructionComponent.swift
+++ b/MapboxDirections/MBVisualInstructionComponent.swift
@@ -31,12 +31,20 @@ open class VisualInstructionComponent: NSObject, NSSecureCoding {
     */
     @objc public var imageURL: URL?
     
+    
+    /**
+     :nodoc:
+     `Bool` whether the `VisualInstructionComponent` should be visualized as a delimiter between two text components.
+     */
+    @objc public var isDelimiter: Bool
+    
     /**
      :nodoc:
      Initialize A `VisualInstructionComponent`.
      */
     @objc public convenience init(json: [String: Any]) {
         let text = json["text"] as? String
+        let isDelimiter = json["delimiter"] as? Bool ?? false
         
         var imageURL: URL?
         
@@ -52,16 +60,17 @@ open class VisualInstructionComponent: NSObject, NSSecureCoding {
             imageURL = URL(string: "\(baseURL)@\(Int(scale))x.png")
         }
         
-        self.init(text: text, imageURL: imageURL)
+        self.init(text: text, imageURL: imageURL, isDelimiter: isDelimiter)
     }
     
     /**
      :nodoc:
      Initialize A `VisualInstructionComponent`.
      */
-    @objc public init(text: String?, imageURL: URL?) {
+    @objc public init(text: String?, imageURL: URL?, isDelimiter: Bool) {
         self.text = text
         self.imageURL = imageURL
+        self.isDelimiter = isDelimiter
     }
 
     @objc public required init?(coder decoder: NSCoder) {
@@ -74,6 +83,8 @@ open class VisualInstructionComponent: NSObject, NSSecureCoding {
             return nil
         }
         self.imageURL = imageURL
+        
+        self.isDelimiter = decoder.decodeBool(forKey: "isDelimiter")
     }
     
     open static var supportsSecureCoding = true
@@ -81,5 +92,6 @@ open class VisualInstructionComponent: NSObject, NSSecureCoding {
     public func encode(with coder: NSCoder) {
         coder.encode(text, forKey: "text")
         coder.encode(imageURL, forKey: "imageURL")
+        coder.encode(isDelimiter, forKey: "isDelimiter")
     }
 }

--- a/MapboxDirections/MBVisualInstructionComponent.swift
+++ b/MapboxDirections/MBVisualInstructionComponent.swift
@@ -34,7 +34,7 @@ open class VisualInstructionComponent: NSObject, NSSecureCoding {
     
     /**
      :nodoc:
-     The type of the `VisualInstructionComponent`. Used for influencing how the compomenent is rendered.
+     The type of visual instruction component. You can display the component differently depending on its type.
      */
     @objc public var type: VisualInstructionComponentType
     
@@ -64,14 +64,14 @@ open class VisualInstructionComponent: NSObject, NSSecureCoding {
             imageURL = URL(string: "\(baseURL)@\(Int(scale))x.png")
         }
         
-        self.init(text: text, imageURL: imageURL, type: type!)
+        self.init(type: type!, text: text, imageURL: imageURL)
     }
     
     /**
      :nodoc:
      Initialize A `VisualInstructionComponent`.
      */
-    @objc public init(text: String?, imageURL: URL?, type: VisualInstructionComponentType) {
+    @objc public init(type: VisualInstructionComponentType, text: String?, imageURL: URL?) {
         self.text = text
         self.imageURL = imageURL
         self.type = type

--- a/MapboxDirections/MBVisualInstructionType.swift
+++ b/MapboxDirections/MBVisualInstructionType.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 /**
- `VisualCompomentType` describes the `text` type.
+ `VisualInstructionComponentType` describes the type of `VisualInstructionComponent`.
  */
 @objc(MBVisualInstructionComponentType)
 public enum VisualInstructionComponentType: Int, CustomStringConvertible {

--- a/MapboxDirections/MBVisualInstructionType.swift
+++ b/MapboxDirections/MBVisualInstructionType.swift
@@ -1,0 +1,40 @@
+import Foundation
+
+/**
+ `VisualCompomentType` describes the `text` type.
+ */
+@objc(MBVisualInstructionComponentType)
+public enum VisualInstructionComponentType: Int, CustomStringConvertible {
+    
+    /**
+     Text is a delimiter.
+     */
+    case delimiter
+    
+    /**
+     Text is a way name.
+     */
+    case destination
+    
+    public init?(description: String) {
+        let level: VisualInstructionComponentType
+        switch description {
+        case "delimiter":
+            level = .delimiter
+        case "destination":
+            level = .destination
+        default:
+            return nil
+        }
+        self.init(rawValue: level.rawValue)
+    }
+    
+    public var description: String {
+        switch self {
+        case .delimiter:
+            return "delimiter"
+        case .destination:
+            return "destination"
+        }
+    }
+}

--- a/MapboxDirections/MBVisualInstructionType.swift
+++ b/MapboxDirections/MBVisualInstructionType.swift
@@ -7,26 +7,28 @@ import Foundation
 public enum VisualInstructionComponentType: Int, CustomStringConvertible {
     
     /**
-     Text is a delimiter.
+     The component separates two other destination components.
+     
+     If the two adjacent components are both displayed as images, you can hide this delimiter component.
      */
     case delimiter
     
     /**
-     Text is a way name.
+     The component bears an exit number or the name of a place or street.
      */
     case destination
     
     public init?(description: String) {
-        let level: VisualInstructionComponentType
+        let type: VisualInstructionComponentType
         switch description {
         case "delimiter":
-            level = .delimiter
+            type = .delimiter
         case "destination":
-            level = .destination
+            type = .destination
         default:
             return nil
         }
-        self.init(rawValue: level.rawValue)
+        self.init(rawValue: type.rawValue)
     }
     
     public var description: String {


### PR DESCRIPTION
Adds the bool `isDelimiter` to `VisualInstructionComponent` indicating that the component should be visualized as a delimiter in the UI.

/cc @mapbox/navigation-ios 