### PR TITLE
Expose more RouteStep properties to Obj-C

### DIFF
--- a/Directions Example/ViewController.m
+++ b/Directions Example/ViewController.m
@@ -59,7 +59,7 @@ NSString * const MapboxAccessToken = @"<# your Mapbox access token #>";
             for (MBRouteStep *step in leg.steps) {
                 NSLog(@"%@", step.instructions);
                 NSString *formattedDistance = [distanceFormatter stringFromMeters:step.distance];
-                NSLog(@"— %@ —", formattedDistance);
+                NSLog(@"— %@ — %ld -", formattedDistance, (long)step.maneuverType);
             }
             
             if (route.coordinateCount) {

--- a/Directions Example/ViewController.m
+++ b/Directions Example/ViewController.m
@@ -59,7 +59,7 @@ NSString * const MapboxAccessToken = @"<# your Mapbox access token #>";
             for (MBRouteStep *step in leg.steps) {
                 NSLog(@"%@", step.instructions);
                 NSString *formattedDistance = [distanceFormatter stringFromMeters:step.distance];
-                NSLog(@"— %@ — %ld -", formattedDistance, (long)step.maneuverType);
+                NSLog(@"— %@ — %ld - %ld -", formattedDistance, (long)step.maneuverType, step.maneuverDirection);
             }
             
             if (route.coordinateCount) {

--- a/Directions Example/ViewController.m
+++ b/Directions Example/ViewController.m
@@ -59,7 +59,7 @@ NSString * const MapboxAccessToken = @"<# your Mapbox access token #>";
             for (MBRouteStep *step in leg.steps) {
                 NSLog(@"%@", step.instructions);
                 NSString *formattedDistance = [distanceFormatter stringFromMeters:step.distance];
-                NSLog(@"— %@ — %ld - %ld -", formattedDistance, (long)step.maneuverType, step.maneuverDirection);
+                NSLog(@"— %@ — %ld - %ld - %ld -", formattedDistance, step.maneuverType, step.maneuverDirection, step.transportType);
             }
             
             if (route.coordinateCount) {

--- a/MapboxDirections/MBRouteStep.swift
+++ b/MapboxDirections/MBRouteStep.swift
@@ -8,6 +8,13 @@ public enum TransportType: Int, CustomStringConvertible {
     // Possible transport types when the `profileIdentifier` is `MBDirectionsProfileIdentifierAutomobile` or `MBDirectionsProfileIdentifierAutomobileAvoidingTraffic`
     
     /**
+     The step does not have a particular transport type associated with it.
+     
+     This transport type is used as a workaround for bridging to Objective-C which does not support nullable enumeration-typed values.
+     */
+    case none
+    
+    /**
      The route requires the user to drive or ride a car, truck, or motorcycle.
      
      This is the usual transport type when the `profileIdentifier` is `MBDirectionsProfileIdentifierAutomobile` or `MBDirectionsProfileIdentifierAutomobileAvoidingTraffic`.
@@ -63,6 +70,8 @@ public enum TransportType: Int, CustomStringConvertible {
     public init?(description: String) {
         let type: TransportType
         switch description {
+        case "none":
+            type = .none
         case "driving":
             type = .automobile
         case "ferry":
@@ -85,6 +94,8 @@ public enum TransportType: Int, CustomStringConvertible {
     
     public var description: String {
         switch self {
+        case .none:
+            return "none"
         case .automobile:
             return "driving"
         case .ferry:
@@ -546,7 +557,7 @@ open class RouteStep: NSObject, NSSecureCoding {
     // MARK: Creating a Step
     
     internal init(finalHeading: CLLocationDirection?, maneuverType: ManeuverType, maneuverDirection: ManeuverDirection, drivingSide: DrivingSide, maneuverLocation: CLLocationCoordinate2D, name: String, coordinates: [CLLocationCoordinate2D]?, json: JSONDictionary) {
-        transportType = TransportType(description: json["mode"] as! String)
+        transportType = TransportType(description: json["mode"] as! String)!
         
         let road = Road(name: name, ref: json["ref"] as? String, exits: json["exits"] as? String, destination: json["destinations"] as? String, rotaryName: json["rotary_name"] as? String)
         if maneuverType == .takeRotary || maneuverType == .takeRoundabout {
@@ -685,7 +696,7 @@ open class RouteStep: NSObject, NSSecureCoding {
         guard let transportTypeDescription = decoder.decodeObject(of: NSString.self, forKey: "transportType") as String? else {
             return nil
         }
-        transportType = TransportType(description: transportTypeDescription)
+        transportType = TransportType(description: transportTypeDescription) ?? .none
         
         codes = decoder.decodeObject(of: [NSArray.self, NSString.self], forKey: "codes") as? [String]
         destinationCodes = decoder.decodeObject(of: [NSArray.self, NSString.self], forKey: "destinationCodes") as? [String]
@@ -738,7 +749,7 @@ open class RouteStep: NSObject, NSSecureCoding {
         coder.encode(expectedTravelTime, forKey: "expectedTravelTime")
         coder.encode(names, forKey: "names")
         coder.encode(phoneticNames, forKey: "phoneticNames")
-        coder.encode(transportType?.description, forKey: "transportType")
+        coder.encode(transportType.description, forKey: "transportType")
         coder.encode(codes, forKey: "codes")
         coder.encode(destinationCodes, forKey: "destinationCodes")
         coder.encode(destinations, forKey: "destinations")
@@ -947,7 +958,7 @@ open class RouteStep: NSObject, NSSecureCoding {
      
      This step may use a different mode of transportation than the overall route.
      */
-    open let transportType: TransportType?
+    @objc open let transportType: TransportType
     
     /**
      Any route reference codes that appear on guide signage for the road leading from this step’s maneuver to the next step’s maneuver.

--- a/MapboxDirections/MBRouteStep.swift
+++ b/MapboxDirections/MBRouteStep.swift
@@ -258,7 +258,7 @@ public enum ManeuverType: Int, CustomStringConvertible {
      */
     case passWaypoint // v4
     
-    public init(description: String) {
+    public init?(description: String) {
         let type: ManeuverType
         switch description {
         case "depart":
@@ -300,7 +300,7 @@ public enum ManeuverType: Int, CustomStringConvertible {
         default:
             type = .none
         }
-        self.init(rawValue: type.rawValue)!
+        self.init(rawValue: type.rawValue)
     }
     
     public var description: String {
@@ -557,7 +557,7 @@ open class RouteStep: NSObject, NSSecureCoding {
     // MARK: Creating a Step
     
     internal init(finalHeading: CLLocationDirection?, maneuverType: ManeuverType, maneuverDirection: ManeuverDirection, drivingSide: DrivingSide, maneuverLocation: CLLocationCoordinate2D, name: String, coordinates: [CLLocationCoordinate2D]?, json: JSONDictionary) {
-        transportType = TransportType(description: json["mode"] as! String)!
+        transportType = TransportType(description: json["mode"] as! String) ?? .none
         
         let road = Road(name: name, ref: json["ref"] as? String, exits: json["exits"] as? String, destination: json["destinations"] as? String, rotaryName: json["rotary_name"] as? String)
         if maneuverType == .takeRotary || maneuverType == .takeRoundabout {
@@ -623,10 +623,10 @@ open class RouteStep: NSObject, NSSecureCoding {
     @objc public convenience init(json: [String: Any]) {
         let maneuver = json["maneuver"] as! JSONDictionary
         let finalHeading = maneuver["bearing_after"] as? Double
-        let maneuverType = ManeuverType(description: maneuver["type"] as! String)
-        let maneuverDirection = ManeuverDirection(description: maneuver["modifier"] as? String ?? ManeuverDirection.none.description)!
+        let maneuverType = ManeuverType(description: maneuver["type"] as? String ?? "") ?? .none
+        let maneuverDirection = ManeuverDirection(description: maneuver["modifier"] as? String ?? "") ?? .none
         let maneuverLocation = CLLocationCoordinate2D(geoJSON: maneuver["location"] as! [Double])
-        let drivingSide = DrivingSide(description: json["driving_side"] as! String) ?? .right
+        let drivingSide = DrivingSide(description: json["driving_side"] as? String ?? "") ?? .right
         
         let name = json["name"] as! String
         
@@ -665,10 +665,10 @@ open class RouteStep: NSObject, NSSecureCoding {
         guard let maneuverTypeDescription = decoder.decodeObject(of: NSString.self, forKey: "maneuverType") as String? else {
             return nil
         }
-        maneuverType = ManeuverType(description: maneuverTypeDescription)
+        maneuverType = ManeuverType(description: maneuverTypeDescription) ?? .none
         
         let maneuverDirectionDescription = decoder.decodeObject(of: NSString.self, forKey: "maneuverDirection")! as String
-        maneuverDirection = ManeuverDirection(description: maneuverDirectionDescription)!
+        maneuverDirection = ManeuverDirection(description: maneuverDirectionDescription) ?? .none
         
         if let drivingSideDescription = decoder.decodeObject(of: NSString.self, forKey: "drivingSide") as String?, let drivingSide = DrivingSide(description: drivingSideDescription) {
             self.drivingSide = drivingSide
@@ -1029,8 +1029,8 @@ internal class RouteStepV4: RouteStep {
     internal convenience init(json: JSONDictionary) {
         let maneuver = json["maneuver"] as! JSONDictionary
         let heading = maneuver["heading"] as? Double
-        let maneuverType = ManeuverType(v4Description: maneuver["type"] as! String)!
-        let maneuverDirection = ManeuverDirection(v4TypeDescription: maneuver["type"] as! String)!
+        let maneuverType = ManeuverType(v4Description: maneuver["type"] as! String) ?? .none
+        let maneuverDirection = ManeuverDirection(v4TypeDescription: maneuver["type"] as! String) ?? .none
         let maneuverLocation = CLLocationCoordinate2D(geoJSON: maneuver["location"] as! JSONDictionary)
         let drivingSide = DrivingSide(description: json["driving_side"] as! String) ?? .right
         let name = json["way_name"] as! String

--- a/MapboxDirectionsTests/V4Tests.swift
+++ b/MapboxDirectionsTests/V4Tests.swift
@@ -71,7 +71,7 @@ class V4Tests: XCTestCase {
         XCTAssertNotNil(step.names)
         XCTAssertEqual(step.names ?? [], ["I 80", "US 93 Alternate"])
         XCTAssertEqual(step.maneuverType, .continue)
-        XCTAssertNil(step.maneuverDirection)
+        XCTAssert(step.maneuverDirection == .none)
         XCTAssertNil(step.initialHeading)
         XCTAssertNil(step.finalHeading)
         


### PR DESCRIPTION
Fixes #117 

`maneuverType`, `maneuverDirection`, and `transportType` now bridges to Obj-C.

Another way to expose these properties to Obj-C could be to add an additional computed non-optional `bridgableManeuverType` if optional chaining syntax is preferred.

<details>

```swift
@objc open var bridgableManeuverType: ManeuverType {
    get {
        return maneuverType ?? .none
    }
}
```

</details>
<br>
@1ec5 @bsudekum 👀 