### PR TITLE
Avoid force unwrapping driving side

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -1,0 +1,4 @@
+opt_in_rules:
+    - force_unwrapping
+excluded: # paths to ignore during linting. Takes precedence over `included`.
+  - Carthage

--- a/MapboxDirections/MBRouteStep.swift
+++ b/MapboxDirections/MBRouteStep.swift
@@ -1032,7 +1032,7 @@ internal class RouteStepV4: RouteStep {
         let maneuverType = ManeuverType(v4Description: maneuver["type"] as! String) ?? .none
         let maneuverDirection = ManeuverDirection(v4TypeDescription: maneuver["type"] as! String) ?? .none
         let maneuverLocation = CLLocationCoordinate2D(geoJSON: maneuver["location"] as! JSONDictionary)
-        let drivingSide = DrivingSide(description: json["driving_side"] as! String) ?? .right
+        let drivingSide = DrivingSide(description: json["driving_side"] as? String ?? "") ?? .right
         let name = json["way_name"] as! String
         
         self.init(finalHeading: heading, maneuverType: maneuverType, maneuverDirection: maneuverDirection, drivingSide: drivingSide, maneuverLocation: maneuverLocation, name: name, coordinates: nil, json: json)


### PR DESCRIPTION
Graceful unwrapping of V5 route step driving side was fixed in #227 
Also added swiftlint but haven't enforced it so far. Hoping to avoid hundreds of conflicts in #221

@bsudekum @1ec5 👀 