### PR TITLE
Add tunnel RoadClass

### DIFF
--- a/MapboxDirections/MBRoadClasses.h
+++ b/MapboxDirections/MBRoadClasses.h
@@ -32,4 +32,9 @@ typedef NS_OPTIONS(NSUInteger, MBRoadClasses) {
      In general, the transport type of the step containing the road segment is also `TransportType.ferry`.
      */
     MBRoadClassesFerry = (1 << 4),
+    
+    /**
+     The user must travel this segment of the route through a [tunnel](https://wiki.openstreetmap.org/wiki/Key:tunnel).
+     */
+    MBRoadClassesTunnel = (1 << 5),
 };

--- a/MapboxDirections/MBRoadClasses.swift
+++ b/MapboxDirections/MBRoadClasses.swift
@@ -19,6 +19,8 @@ extension RoadClasses: CustomStringConvertible {
                 roadClasses.insert(.motorway)
             case "ferry":
                 roadClasses.insert(.ferry)
+            case "tunnel":
+                roadClasses.insert(.tunnel)
             case "none":
                 break
             default:
@@ -45,6 +47,9 @@ extension RoadClasses: CustomStringConvertible {
         }
         if contains(.ferry) {
             descriptions.append("ferry")
+        }
+        if contains(.tunnel) {
+            descriptions.append("tunnel")
         }
         return descriptions.joined(separator: ",")
     }


### PR DESCRIPTION
The RoadClass tunnel has been added to the Directions API.

/cc @mapbox/navigation-ios 