### PR TITLE
Changed access level of MBRouteOptions response function & MBRouteStep instructions parameter

### DIFF
--- a/MapboxDirections/MBRouteOptions.swift
+++ b/MapboxDirections/MBRouteOptions.swift
@@ -477,7 +477,7 @@ open class RouteOptions: NSObject, NSSecureCoding, NSCopying{
      - parameter json: The API response in JSON dictionary format.
      - returns: A tuple containing an array of waypoints and an array of routes.
      */
-    internal func response(from json: JSONDictionary) -> ([Waypoint]?, [Route]?) {
+    public func response(from json: JSONDictionary) -> ([Waypoint]?, [Route]?) {
         var namedWaypoints: [Waypoint]?
         if let jsonWaypoints = (json["waypoints"] as? [JSONDictionary]) {
             namedWaypoints = zip(jsonWaypoints, self.waypoints).map { (api, local) -> Waypoint in

--- a/MapboxDirections/MBRouteStep.swift
+++ b/MapboxDirections/MBRouteStep.swift
@@ -813,7 +813,7 @@ open class RouteStep: NSObject, NSSecureCoding {
      
      - note: If you use MapboxDirections.swift with the Mapbox Directions API, this property is formatted and localized for display to the user. If you use OSRM directly, this property contains a basic string that only includes the maneuver type and direction. Use [OSRM Text Instructions](https://github.com/Project-OSRM/osrm-text-instructions.swift/) to construct a complete, localized instruction string for display.
      */
-    @objc open let instructions: String
+    @objc open var instructions: String
     
     /**
      Instructions about the next step’s maneuver, optimized for speech synthesis.


### PR DESCRIPTION
* ### Changed access level for `response(from json: JSONDictionary)` function from `internal` to `public`
Our backend, similar to Mapbox backend, can create Routes to navigate. Accordingly, we are interested that the method responsible for parsing route JSON file should be public, because we receive the route JSON file from our server outside of the Mapbox framework. 
* ### `instructions` parameter changed from `let` to `var`
Several of our custom routes have special instructions, which cannot be loaded while creating Route objects. We would like `MBRouteStep`'s `instructions` parameter to be declared as a variable, allowing it to be changed dynamically after the Route object is created. 

We believe these changes will be useful for other customers of MapboxDirections.swift.
