### PR TITLE
Fix swift 4.1 fatal issue

### DIFF
--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,3 +1,3 @@
-binary "https://www.mapbox.com/ios-sdk/Mapbox-iOS-SDK.json" "3.7.3"
+binary "https://www.mapbox.com/ios-sdk/Mapbox-iOS-SDK.json" "3.7.6"
 github "AliSoftware/OHHTTPStubs" "6.1.0"
 github "raphaelmor/Polyline" "v4.2.0"

--- a/MapboxDirections/Match/MBMatch.swift
+++ b/MapboxDirections/Match/MBMatch.swift
@@ -42,7 +42,7 @@ open class Match: DirectionsResult {
             coordinates = nil
         }
         
-        let confidence = json["confidence"] as! Float
+        let confidence = (json["confidence"] as! NSNumber).floatValue
         
         var speechLocale: Locale?
         if let locale = json["voiceLocale"] as? String {


### PR DESCRIPTION
This line fails when running tests in xcode 9.3 with swift 4.1 with the following error:

```
Fatal error: Unable to bridge NSNumber to Float: 
```