### PR TITLE
Make compatible with swift 4.1

### DIFF
--- a/MapboxDirections.xcodeproj/project.pbxproj
+++ b/MapboxDirections.xcodeproj/project.pbxproj
@@ -69,6 +69,7 @@
 		C57D55041DB566A800B94B74 /* MBIntersection.swift in Sources */ = {isa = PBXBuildFile; fileRef = C57D55001DB5669600B94B74 /* MBIntersection.swift */; };
 		C57D55051DB566A900B94B74 /* MBIntersection.swift in Sources */ = {isa = PBXBuildFile; fileRef = C57D55001DB5669600B94B74 /* MBIntersection.swift */; };
 		C57D55081DB58C0200B94B74 /* MBLane.swift in Sources */ = {isa = PBXBuildFile; fileRef = C57D55071DB58C0200B94B74 /* MBLane.swift */; };
+		C582BA2E2073ED6300647DAA /* Array.swift in Sources */ = {isa = PBXBuildFile; fileRef = C582BA2D2073ED6300647DAA /* Array.swift */; };
 		C584E3F71F201C7B00BBC9BB /* MBRoadClasses.swift in Sources */ = {isa = PBXBuildFile; fileRef = C59426061F1EA6C400C8E59C /* MBRoadClasses.swift */; };
 		C584E3F81F201C7C00BBC9BB /* MBRoadClasses.swift in Sources */ = {isa = PBXBuildFile; fileRef = C59426061F1EA6C400C8E59C /* MBRoadClasses.swift */; };
 		C584E3F91F201C7D00BBC9BB /* MBRoadClasses.swift in Sources */ = {isa = PBXBuildFile; fileRef = C59426061F1EA6C400C8E59C /* MBRoadClasses.swift */; };
@@ -268,6 +269,7 @@
 		C57B2E951DB8171300E9123A /* MBLaneIndication.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MBLaneIndication.h; sourceTree = "<group>"; };
 		C57D55001DB5669600B94B74 /* MBIntersection.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MBIntersection.swift; sourceTree = "<group>"; };
 		C57D55071DB58C0200B94B74 /* MBLane.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MBLane.swift; sourceTree = "<group>"; };
+		C582BA2D2073ED6300647DAA /* Array.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Array.swift; sourceTree = "<group>"; };
 		C584E3FA1F2027EE00BBC9BB /* MBRoadClasses.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MBRoadClasses.h; sourceTree = "<group>"; };
 		C58EA7A91E9D7EAD008F98CE /* MBCongestion.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MBCongestion.swift; sourceTree = "<group>"; };
 		C59094B4203B5C7F00EB2417 /* MBDrawingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MBDrawingView.swift; sourceTree = "<group>"; };
@@ -442,6 +444,7 @@
 			isa = PBXGroup;
 			children = (
 				8D381B691FDB101F008D5A58 /* String.swift */,
+				C582BA2D2073ED6300647DAA /* Array.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -1241,6 +1244,7 @@
 			files = (
 				C51538CC1E807FF00093FF3E /* MBAttribute.swift in Sources */,
 				DA2E03EB1CB0E13D00D1269A /* MBRouteOptions.swift in Sources */,
+				C582BA2E2073ED6300647DAA /* Array.swift in Sources */,
 				C52552B91FA15D5900B1545C /* MBVisualInstruction.swift in Sources */,
 				C52552C01FA1628A00B1545C /* MBVisualInstructionComponent.swift in Sources */,
 				C59426071F1EA6C400C8E59C /* MBRoadClasses.swift in Sources */,

--- a/MapboxDirections.xcodeproj/project.pbxproj
+++ b/MapboxDirections.xcodeproj/project.pbxproj
@@ -48,6 +48,9 @@
 		C53A022C1E92C281009837BD /* annotation.json in Resources */ = {isa = PBXBuildFile; fileRef = C5A3D3971E8188FE00D494A0 /* annotation.json */; };
 		C5434B8A200693D00069E887 /* MBTracepoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5434B89200693D00069E887 /* MBTracepoint.swift */; };
 		C5434B8C200695A50069E887 /* MBMatchOptions.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5434B8B200695A50069E887 /* MBMatchOptions.swift */; };
+		C54549FC2073F1EF002E273F /* Array.swift in Sources */ = {isa = PBXBuildFile; fileRef = C582BA2D2073ED6300647DAA /* Array.swift */; };
+		C54549FD2073F1F0002E273F /* Array.swift in Sources */ = {isa = PBXBuildFile; fileRef = C582BA2D2073ED6300647DAA /* Array.swift */; };
+		C54549FE2073F1F1002E273F /* Array.swift in Sources */ = {isa = PBXBuildFile; fileRef = C582BA2D2073ED6300647DAA /* Array.swift */; };
 		C547EC691DB59F8F009817F3 /* MBLane.swift in Sources */ = {isa = PBXBuildFile; fileRef = C57D55071DB58C0200B94B74 /* MBLane.swift */; };
 		C547EC6A1DB59F90009817F3 /* MBLane.swift in Sources */ = {isa = PBXBuildFile; fileRef = C57D55071DB58C0200B94B74 /* MBLane.swift */; };
 		C547EC6B1DB59F91009817F3 /* MBLane.swift in Sources */ = {isa = PBXBuildFile; fileRef = C57D55071DB58C0200B94B74 /* MBLane.swift */; };
@@ -1137,6 +1140,7 @@
 				C58EA7AB1E9D7F73008F98CE /* MBCongestion.swift in Sources */,
 				8D381B6B1FDB3D8A008D5A58 /* String.swift in Sources */,
 				C56516851FE1AB8F00A0AD18 /* MBVisualInstructionType.swift in Sources */,
+				C54549FC2073F1EF002E273F /* Array.swift in Sources */,
 				C547EC691DB59F8F009817F3 /* MBLane.swift in Sources */,
 				DA1A10C71D00F969009F82FA /* MBDirections.swift in Sources */,
 			);
@@ -1185,6 +1189,7 @@
 				C58EA7AC1E9D7F74008F98CE /* MBCongestion.swift in Sources */,
 				8D381B6C1FDB3D8B008D5A58 /* String.swift in Sources */,
 				C56516861FE1AB9000A0AD18 /* MBVisualInstructionType.swift in Sources */,
+				C54549FD2073F1F0002E273F /* Array.swift in Sources */,
 				C547EC6A1DB59F90009817F3 /* MBLane.swift in Sources */,
 				DA1A10ED1D010247009F82FA /* MBDirections.swift in Sources */,
 			);
@@ -1233,6 +1238,7 @@
 				C58EA7AD1E9D7F75008F98CE /* MBCongestion.swift in Sources */,
 				8D381B6D1FDB3D8B008D5A58 /* String.swift in Sources */,
 				C56516871FE1AB9100A0AD18 /* MBVisualInstructionType.swift in Sources */,
+				C54549FE2073F1F1002E273F /* Array.swift in Sources */,
 				C547EC6B1DB59F91009817F3 /* MBLane.swift in Sources */,
 				DA1A11041D0103A3009F82FA /* MBDirections.swift in Sources */,
 			);

--- a/MapboxDirections/Extensions/Array.swift
+++ b/MapboxDirections/Extensions/Array.swift
@@ -1,0 +1,9 @@
+import Foundation
+
+extension Array {
+    #if !swift(>=4.1)
+    func compactMap<ElementOfResult>(_ transform: (Element) throws -> ElementOfResult?) rethrows -> [ElementOfResult] {
+        return try flatMap(transform)
+    }
+    #endif
+}

--- a/MapboxDirections/MBDirectionsResult.swift
+++ b/MapboxDirections/MBDirectionsResult.swift
@@ -19,7 +19,7 @@ open class DirectionsResult: NSObject, NSSecureCoding {
         
     @objc public required init?(coder decoder: NSCoder) {
         let coordinateDictionaries = decoder.decodeObject(of: [NSArray.self, NSDictionary.self, NSString.self, NSNumber.self], forKey: "coordinates") as? [[String: CLLocationDegrees]]
-        coordinates = coordinateDictionaries?.flatMap({ (coordinateDictionary) -> CLLocationCoordinate2D? in
+        coordinates = coordinateDictionaries?.compactMap({ (coordinateDictionary) -> CLLocationCoordinate2D? in
             if let latitude = coordinateDictionary["latitude"],
                 let longitude = coordinateDictionary["longitude"] {
                 return CLLocationCoordinate2D(latitude: latitude, longitude: longitude)

--- a/MapboxDirections/MBRouteOptions.swift
+++ b/MapboxDirections/MBRouteOptions.swift
@@ -250,7 +250,7 @@ open class RouteOptionsV4: RouteOptions {
     override func response(from json: JSONDictionary) -> ([Waypoint]?, [Route]?) {
         let sourceWaypoint = Waypoint(geoJSON: json["origin"] as! JSONDictionary)!
         let destinationWaypoint = Waypoint(geoJSON: json["destination"] as! JSONDictionary)!
-        let intermediateWaypoints = (json["waypoints"] as! [JSONDictionary]).flatMap { Waypoint(geoJSON: $0) }
+        let intermediateWaypoints = (json["waypoints"] as! [JSONDictionary]).compactMap { Waypoint(geoJSON: $0) }
         let waypoints = [sourceWaypoint] + intermediateWaypoints + [destinationWaypoint]
         let routes = (json["routes"] as? [JSONDictionary])?.map {
             RouteV4(json: $0, waypoints: waypoints, routeOptions: self)

--- a/MapboxDirections/MBRouteStep.swift
+++ b/MapboxDirections/MBRouteStep.swift
@@ -646,7 +646,7 @@ open class RouteStep: NSObject, NSSecureCoding {
     public required init?(coder decoder: NSCoder) {
         let coordinateDictionaries = decoder.decodeObject(of: [NSArray.self, NSDictionary.self, NSString.self, NSNumber.self], forKey: "coordinates") as? [[String: CLLocationDegrees]]
 		
-        coordinates = coordinateDictionaries?.flatMap({ (coordinateDictionary) -> CLLocationCoordinate2D? in
+        coordinates = coordinateDictionaries?.compactMap({ (coordinateDictionary) -> CLLocationCoordinate2D? in
             if let latitude = coordinateDictionary["latitude"], let longitude = coordinateDictionary["longitude"] {
                 return CLLocationCoordinate2D(latitude: latitude, longitude: longitude)
             } else {

--- a/MapboxDirections/MBSpokenInstruction.swift
+++ b/MapboxDirections/MBSpokenInstruction.swift
@@ -59,8 +59,8 @@ open class SpokenInstruction: NSObject, NSSecureCoding {
     
     public required init?(coder decoder: NSCoder) {
         distanceAlongStep = decoder.decodeDouble(forKey: "distanceAlongStep")
-        text = decoder.decodeObject(of: NSString.self, forKey: "text") as String!
-        ssmlText = decoder.decodeObject(of: NSString.self, forKey: "ssmlText") as String!
+        text = decoder.decodeObject(of: NSString.self, forKey: "text")! as String
+        ssmlText = decoder.decodeObject(of: NSString.self, forKey: "ssmlText")! as String
     }
     
     open static var supportsSecureCoding = true

--- a/MapboxDirections/Match/MBMatchOptions.swift
+++ b/MapboxDirections/Match/MBMatchOptions.swift
@@ -84,7 +84,7 @@ open class MatchOptions: DirectionsOptions {
     }
     
     internal var encodedParam: String {
-        let joinedParams = params.flatMap({ (param) -> String? in
+        let joinedParams = params.compactMap({ (param) -> String? in
             guard let value = param.value else { return nil }
             return "\(param.name)=\(value)"
         }).joined(separator: "&")


### PR DESCRIPTION
This removes a few warnings when compiling with swift 4.1.

Stealing logic from https://github.com/mapbox/mapbox-navigation-ios/pull/1271

/cc @mapbox/navigation-ios 