### PR TITLE
Automate one step in documentation generation

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -5,5 +5,4 @@ Run `scripts/document.sh`
 ## Update the documentation site:
 1. Clone [mapbox-navigation-ios](https://github.com/mapbox/mapbox-navigation-ios) to a mapbox-navigation-ios-docs folder alongside your MapboxDirections.swift clone, and check out the `mb-pages` branch.
 1. In your main MapboxDirections.swift clone, check out the release branch and run `OUTPUT=../mapbox-navigation-ios-docs/directions/X.X.X scripts/document.sh`, where _X.X.X_ is the new SDK version.
-1. In mapbox-navigation-ios-docs, edit [directions/index.html](https://github.com/mapbox/mapbox-navigation-ios/blob/mb-pages/directions/index.html) and directions/docsets/Mapbox.xml to refer to the new SDK version.
 1. Commit and push your changes to the mapbox-navigation-ios `mb-pages` branch.

--- a/scripts/document.sh
+++ b/scripts/document.sh
@@ -41,3 +41,7 @@ jazzy \
 
 find ${OUTPUT} -name *.html -exec \
     perl -pi -e 's/BRANDLESS_DOCSET_TITLE/Directions.swift $1/, s/MapboxDirections.swift\s+(Docs|Reference)/MapboxDirections.swift $1/' {} \;
+
+# Replace version numbers
+sed -i '' -e 's|url=[^0-9.]*\([0-9.]*\)|url='${RELEASE_VERSION}'|g' ${OUTPUT}/../index.html
+sed -i '' -e 's|[0-9.]\([0-9.]\)\([0-9]\)|{x}|g; s|{x}{x}|'${RELEASE_VERSION}'|g' ${OUTPUT}/../docsets/MapboxDirections.xml


### PR DESCRIPTION
Fixes #262 

Simplifies the documentation generation by removing one step.

@1ec5 