### PR TITLE
Refine Objective-C bridging; copyedit documentation

### DIFF
--- a/MapboxDirections/MBDirectionsOptions.swift
+++ b/MapboxDirections/MBDirectionsOptions.swift
@@ -193,7 +193,9 @@ public enum InstructionFormat: UInt, CustomStringConvertible {
 open class DirectionsOptions: NSObject, NSSecureCoding, NSCopying {
     
     /**
-     Initializes a route options object for routes between the given waypoints and an optional profile identifier.
+     Initializes an options object for routes between the given waypoints and an optional profile identifier.
+     
+     Do not call `DirectionsOptions(waypoints:profileIdentifier:)` directly; instead call the corresponding initializer of `RouteOptions` or `MatchOptions`.
      
      - parameter waypoints: An array of `Waypoint` objects representing locations that the route should visit in chronological order. The array should contain at least two waypoints (the source and destination) and at most 25 waypoints. (Some profiles, such as `MBDirectionsProfileIdentifierAutomobileAvoidingTraffic`, [may have lower limits](https://www.mapbox.com/api-documentation/#directions).)
      - parameter profileIdentifier: A string specifying the primary mode of transportation for the routes. This parameter, if set, should be set to `MBDirectionsProfileIdentifierAutomobile`, `MBDirectionsProfileIdentifierAutomobileAvoidingTraffic`, `MBDirectionsProfileIdentifierCycling`, or `MBDirectionsProfileIdentifierWalking`. `MBDirectionsProfileIdentifierAutomobile` is used by default.
@@ -221,7 +223,7 @@ open class DirectionsOptions: NSObject, NSSecureCoding, NSCopying {
         return copy
     }
     
-    //MARK: - OBJ-C Equality
+    // MARK: Objective-C equality
     open override func isEqual(_ object: Any?) -> Bool {
         guard let opts = object as? DirectionsOptions else { return false }
         return isEqual(to: opts)
@@ -396,10 +398,9 @@ open class DirectionsOptions: NSObject, NSSecureCoding, NSCopying {
     @objc open var distanceMeasurementSystem: MeasurementSystem = Locale.autoupdatingCurrent.usesMetric ? .metric : .imperial
     
     /**
-     :nodoc:
      If true, each `RouteStep` will contain the property `visualInstructionsAlongStep`.
      
-     `visualInstructionsAlongStep` contains an array of `VisualInstruction` used for visually conveying information about a given `RouteStep`.
+     `visualInstructionsAlongStep` contains an array of `VisualInstruction` objects used for visually conveying information about a given `RouteStep`.
      */
     @objc open var includesVisualInstructions = false
     

--- a/MapboxDirections/MBLane.swift
+++ b/MapboxDirections/MBLane.swift
@@ -10,11 +10,10 @@ public class Lane: NSObject, NSSecureCoding {
      */
     @objc public let indications: LaneIndication
     
-    
     /**
      Initializes a new `Lane` using the given lane indications.
      */
-    public init(indications: LaneIndication) {
+    @objc public init(indications: LaneIndication) {
         self.indications = indications
     }
     

--- a/MapboxDirections/MBRoute.swift
+++ b/MapboxDirections/MBRoute.swift
@@ -22,7 +22,8 @@ open class Route: DirectionsResult {
      - parameter waypoints: An array of waypoints that the route visits in chronological order.
      - parameter routeOptions: The `RouteOptions` used to create the request.
      */
-    @objc public init(json: [String: Any], waypoints: [Waypoint], routeOptions: RouteOptions) {
+    @objc(initWithJSON:waypoints:routeOptions:)
+    public init(json: [String: Any], waypoints: [Waypoint], routeOptions: RouteOptions) {
         // Associate each leg JSON with a source and destination. The sequence of destinations is offset by one from the sequence of sources.
         let legInfo = zip(zip(waypoints.prefix(upTo: waypoints.endIndex - 1), waypoints.suffix(from: 1)),
                           json["legs"] as? [JSONDictionary] ?? [])

--- a/MapboxDirections/MBRouteLeg.swift
+++ b/MapboxDirections/MBRouteLeg.swift
@@ -62,7 +62,8 @@ open class RouteLeg: NSObject, NSSecureCoding {
      - parameter destination: The waypoint at the end of the leg.
      - parameter profileIdentifier: The profile identifier used to request the routes.
      */
-    @objc public convenience init(json: [String: Any], source: Waypoint, destination: Waypoint, profileIdentifier: MBDirectionsProfileIdentifier) {
+    @objc(initWithJSON:source:destination:profileIdentifier:)
+    public convenience init(json: [String: Any], source: Waypoint, destination: Waypoint, profileIdentifier: MBDirectionsProfileIdentifier) {
         let steps = (json["steps"] as? [JSONDictionary] ?? []).map { RouteStep(json: $0) }
         
         self.init(steps: steps, json: json, source: source, destination: destination, profileIdentifier: profileIdentifier)

--- a/MapboxDirections/MBRouteStep.swift
+++ b/MapboxDirections/MBRouteStep.swift
@@ -614,11 +614,11 @@ open class RouteStep: NSObject, NSSecureCoding {
     }
     
     /**
-     Initializes a new route step object with the given JSON dictionary representation.
+     Initializes a new route step object based on the given JSON dictionary representation.
      
      Normally, you do not create instances of this class directly. Instead, you receive route step objects as part of route objects when you request directions using the `Directions.calculateDirections(options:completionHandler:)` method, setting the `includesSteps` option to `true` in the `RouteOptions` object that you pass into that method.
      
-     - parameter json: A JSON dictionary representation of a route step object as returnd by the Mapbox Directions API.
+     - parameter json: A JSON object that conforms to the [route step](https://www.mapbox.com/api-documentation/#routestep-object) format described in the Directions API documentation.
      */
     @objc(initWithJSON:)
     public convenience init(json: [String: Any]) {
@@ -826,7 +826,6 @@ open class RouteStep: NSObject, NSSecureCoding {
     @objc open let instructionsSpokenAlongStep: [SpokenInstruction]?
     
     /**
-     :nodoc:
      Instructions about the next step’s maneuver, optimized for display in real time.
      
      As the user traverses this step, you can give them advance notice of the upcoming maneuver by displaying each item in this array in order as the user reaches the specified distances along this step. The text and images of the visual instructions refer to the details in the next step, but the distances are measured from the beginning of this step.
@@ -862,7 +861,7 @@ open class RouteStep: NSObject, NSSecureCoding {
     @objc open let maneuverDirection: ManeuverDirection
     
     /**
-     Indicates what side of a bidirectional road the driver must be driving on. Also referred to as the rule of the road.
+     Which side of a bidirectional road the driver should drive on, also known as the rule of the road.
      */
     open let drivingSide: DrivingSide
     

--- a/MapboxDirections/MBRouteStep.swift
+++ b/MapboxDirections/MBRouteStep.swift
@@ -620,7 +620,8 @@ open class RouteStep: NSObject, NSSecureCoding {
      
      - parameter json: A JSON dictionary representation of a route step object as returnd by the Mapbox Directions API.
      */
-    @objc public convenience init(json: [String: Any]) {
+    @objc(initWithJSON:)
+    public convenience init(json: [String: Any]) {
         let maneuver = json["maneuver"] as! JSONDictionary
         let finalHeading = maneuver["bearing_after"] as? Double
         let maneuverType = ManeuverType(description: maneuver["type"] as? String ?? "") ?? .none

--- a/MapboxDirections/MBSpokenInstruction.swift
+++ b/MapboxDirections/MBSpokenInstruction.swift
@@ -36,7 +36,8 @@ open class SpokenInstruction: NSObject, NSSecureCoding {
     /**
      Initialize a `SpokenInstruction` from a dictionary.
      */
-    @objc public convenience init(json: [String: Any]) {
+    @objc(initWithJSON:)
+    public convenience init(json: [String: Any]) {
         let distanceAlongStep = json["distanceAlongGeometry"] as! CLLocationDistance
         let text = json["announcement"] as! String
         let ssmlText = json["ssmlAnnouncement"] as! String

--- a/MapboxDirections/MBSpokenInstruction.swift
+++ b/MapboxDirections/MBSpokenInstruction.swift
@@ -34,7 +34,9 @@ open class SpokenInstruction: NSObject, NSSecureCoding {
     @objc public let ssmlText: String
     
     /**
-     Initialize a `SpokenInstruction` from a dictionary.
+     Initializes a new spoken instruction object based on the given JSON dictionary representation.
+     
+     - parameter json: A JSON object that conforms to the [voice instruction](https://www.mapbox.com/api-documentation/#voice-instruction-object) format described in the Directions API documentation.
      */
     @objc(initWithJSON:)
     public convenience init(json: [String: Any]) {

--- a/MapboxDirections/MBVisualInstruction.swift
+++ b/MapboxDirections/MBVisualInstruction.swift
@@ -58,7 +58,13 @@ open class VisualInstruction: NSObject, NSSecureCoding {
         self.finalHeading = degrees
     }
     
-    @objc public convenience init(json: [String: Any]) {
+    /**
+     Initializes a new visual instruction object based on the given JSON dictionary representation.
+     
+     - parameter json: A JSON object that conforms to the [banner instruction](https://www.mapbox.com/api-documentation/#banner-instruction-object) format described in the Directions API documentation.
+     */
+    @objc(initWithJSON:)
+    public convenience init(json: [String: Any]) {
         let text = json["text"] as? String
         let maneuverType = ManeuverType(description: json["type"] as! String) ?? .none
         let maneuverDirection = ManeuverDirection(description: json["modifier"] as! String)  ?? .none

--- a/MapboxDirections/MBVisualInstruction.swift
+++ b/MapboxDirections/MBVisualInstruction.swift
@@ -1,7 +1,6 @@
 import Foundation
 
 /**
- :nodoc:
  The contents of a banner that should be displayed as added visual guidance for a route. The banner instructions are children of the steps during which they should be displayed, but they refer to the maneuver in the following step.
  */
 @objc(MBVisualInstruction)
@@ -10,45 +9,36 @@ open class VisualInstruction: NSObject, NSSecureCoding {
     open static var supportsSecureCoding = true
     
     /**
-     :nodoc:
-     The plain text representation of this component.
-     
-     Use this property if `imageURLs` is an empty dictionary or if the URLs contained in that property are not yet available.
+     A plain text representation of the instruction.
      */
     @objc public let text: String?
     
     /**
-     :nodoc:
-     The maneuver type for the `VisualInstruction`.
+     The type of maneuver required for beginning the step described by the visual instruction.
      */
     @objc public var maneuverType: ManeuverType
     
     /**
-     :nodoc:
-     The modifier type for the `VisualInstruction`.
+     Additional directional information to clarify the maneuver type.
      */
     @objc public var maneuverDirection: ManeuverDirection
     
     /**
-     :nodoc:
-     Most important visual content to convey to the user about the `RouteStep`.
-     
-     This is the structured representation of `text`.
+     A structured representation of the instruction.
      */
     @objc public let textComponents: [VisualInstructionComponent]
     
     /**
-     :nodoc:
-     The heading at which you will be exiting a roundabout, assuming 180 indicates going straight through the roundabout.
+     The heading at which the user exits a roundabout (traffic circle or rotary).
      
-     Note that this property is only relevant if the `maneuverType` is any of
-     [`ManeuverType.takeRoundabout`, `ManeuverType.takeRotary`, `ManeuverType.turnAtRoundabout`, `ManeuverType.exitRoundabout`, `ManeuverType.exitRotary`]
+     This property is measured in degrees clockwise relative to the user’s initial heading. A value of 180° means continuing through the roundabout without changing course, whereas a value of 0° means traversing the entire roundabout back to the entry point.
+     
+     This property is only relevant if the `maneuverType` is any of the following values: `ManeuverType.takeRoundabout`, `ManeuverType.takeRotary`, `ManeuverType.turnAtRoundabout`, `ManeuverType.exitRoundabout`, or `ManeuverType.exitRotary`.
      */
     @objc public var finalHeading: CLLocationDegrees = 180
     
     /**
-     :nodoc:
-     Initialize A `VisualInstructionBanner`.
+     Initializes a new visual instruction banner object that displays the given information.
      */
     @objc public init(text: String?, maneuverType: ManeuverType, maneuverDirection: ManeuverDirection, textComponents: [VisualInstructionComponent], degrees: CLLocationDegrees = 180) {
         self.text = text

--- a/MapboxDirections/MBVisualInstructionBanner.swift
+++ b/MapboxDirections/MBVisualInstructionBanner.swift
@@ -1,39 +1,36 @@
 import Foundation
 
 /**
- :nodoc:
- Encompasses all information necessary for creating a visual cue about a given `RouteStep`.
+ A visual instruction banner contains all the information necessary for creating a visual cue about a given `RouteStep`.
  */
 @objc(MBVisualInstructionBanner)
 open class VisualInstructionBanner: NSObject, NSSecureCoding {
     
     /**
-     :nodoc:
-     Distance in meters from the beginning of the step at which the visual instruction should be visible.
+     The distance at which the visual instruction should be shown, measured in meters from the beginning of the step.
      */
     @objc public let distanceAlongStep: CLLocationDistance
 
     /**
-     :nodoc:
-     Most important visual content to convey to the user about the `RouteStep`.
+     The most important information to convey to the user about the `RouteStep`.
      */
     @objc public let primaryInstruction: VisualInstruction
     
     /**
-     :nodoc:
-     Ancillary visual information about the `RouteStep`.
+     Less important details about the `RouteStep`.
      */
     @objc public let secondaryInstruction: VisualInstruction?
     
     /**
-     :nodoc:
-     Indicates what side of a bidirectional road the driver must be driving on. Also referred to as the rule of the road.
+     Which side of a bidirectional road the driver should drive on, also known as the rule of the road.
      */
     @objc public var drivingSide: DrivingSide
     
     /**
-     :nodoc:
-     Initialize a `VisualInstruction` from a dictionary given a `DrivingSide`.
+     Initializes a new visual instruction banner object based on the given JSON dictionary representation and a driving side.
+     
+     - parameter json: A JSON object that conforms to the [primary or secondary banner](https://www.mapbox.com/api-documentation/#banner-instruction-object) format described in the Directions API documentation.
+     - parameter drivingSide: The side of the road the user should drive on. This value should be consistent with the containing route step.
      */
     @objc(initWithJSON:drivingSide:)
     public convenience init(json: [String: Any], drivingSide: DrivingSide) {
@@ -52,8 +49,12 @@ open class VisualInstructionBanner: NSObject, NSSecureCoding {
     }
     
     /**
-     :nodoc:
-     Initialize a `VisualInstruction`.
+     Initializes a new visual instruction banner object that displays the given information.
+     
+     - parameter distanceAlongStep: The distance at which the visual instruction should be shown, measured in meters from the beginning of the step.
+     - parameter primaryInstruction: The most important information to convey to the user about the `RouteStep`.
+     - parameter secondaryInstruction: Less important details about the `RouteStep`.
+     - parameter drivingSide: Which side of a bidirectional road the driver should drive on.
      */
     @objc public init(distanceAlongStep: CLLocationDistance, primaryInstruction: VisualInstruction, secondaryInstruction: VisualInstruction?, drivingSide: DrivingSide) {
         self.distanceAlongStep = distanceAlongStep

--- a/MapboxDirections/MBVisualInstructionBanner.swift
+++ b/MapboxDirections/MBVisualInstructionBanner.swift
@@ -35,7 +35,8 @@ open class VisualInstructionBanner: NSObject, NSSecureCoding {
      :nodoc:
      Initialize a `VisualInstruction` from a dictionary given a `DrivingSide`.
      */
-    @objc public convenience init(json: [String: Any], drivingSide: DrivingSide) {
+    @objc(initWithJSON:drivingSide:)
+    public convenience init(json: [String: Any], drivingSide: DrivingSide) {
         let distanceAlongStep = json["distanceAlongGeometry"] as! CLLocationDistance
         
         let primary = json["primary"] as! JSONDictionary

--- a/MapboxDirections/MBVisualInstructionComponent.swift
+++ b/MapboxDirections/MBVisualInstructionComponent.swift
@@ -9,28 +9,24 @@ import Foundation
 #endif
 
 /**
- :nodoc:
  A component of a `VisualInstruction` that represents a single run of similarly formatted text or an image with a textual fallback representation.
  */
 @objc(MBVisualInstructionComponent)
 open class VisualInstructionComponent: NSObject, NSSecureCoding {
     
     /**
-     :nodoc:
      The plain text representation of this component.
      
-     Use this property if `imageURLs` is an empty dictionary or if the URLs contained in that property are not yet available.
+     Use this property if `imageURL` is `nil` or if the URL contained in that property is not yet available.
      */
     @objc public let text: String?
     
     /**
-     :nodoc:
      The type of visual instruction component. You can display the component differently depending on its type.
      */
     @objc public var type: VisualInstructionComponentType
     
     /**
-     :nodoc:
     The URL to an image representation of this component.
  
     The URL refers to an image that uses the device’s native screen scale.
@@ -38,18 +34,21 @@ open class VisualInstructionComponent: NSObject, NSSecureCoding {
     @objc public var imageURL: URL?
     
     /**
-     An abbreviated version of the text for a given component.
+     An abbreviated representation of the `text` property.
      */
     @objc public var abbreviation: String?
     
     /**
-     The priority in which the component should be abbreviated. Lower numbers should be abbreviated first.
+     The priority for which the component should be abbreviated.
+     
+     A component with a lower abbreviation priority value should be abbreviated before a component with a higher abbreviation priority value.
      */
     @objc public var abbreviationPriority: Int = NSNotFound
     
     /**
-     :nodoc:
-     Initialize A `VisualInstructionComponent`.
+     Initializes a new visual instruction component object based on the given JSON dictionary representation.
+     
+     - parameter json: A JSON object that conforms to the [banner component](https://www.mapbox.com/api-documentation/#banner-instruction-object) format described in the Directions API documentation.
      */
     @objc(initWithJSON:)
     public convenience init(json: [String: Any]) {
@@ -76,8 +75,13 @@ open class VisualInstructionComponent: NSObject, NSSecureCoding {
     }
     
     /**
-     :nodoc:
-     Initialize A `VisualInstructionComponent`.
+     Initializes a new visual instruction component object that displays the given information.
+     
+     - parameter type: The type of visual instruction component.
+     - parameter text: The plain text representation of this component.
+     - parameter imageURL: The URL to an image representation of this component.
+     - parameter abbreviation: An abbreviated representation of `text`.
+     - parameter abbreviationPriority: The priority for which the component should be abbreviated.
      */
     @objc public init(type: VisualInstructionComponentType, text: String?, imageURL: URL?, abbreviation: String?, abbreviationPriority: Int) {
         self.text = text

--- a/MapboxDirections/MBVisualInstructionComponent.swift
+++ b/MapboxDirections/MBVisualInstructionComponent.swift
@@ -51,7 +51,8 @@ open class VisualInstructionComponent: NSObject, NSSecureCoding {
      :nodoc:
      Initialize A `VisualInstructionComponent`.
      */
-    @objc public convenience init(json: [String: Any]) {
+    @objc(initWithJSON:)
+    public convenience init(json: [String: Any]) {
         let text = json["text"] as? String
         let type = VisualInstructionComponentType(description: json["type"] as? String ?? "") ?? .text
         

--- a/MapboxDirections/Match/MBMatch.swift
+++ b/MapboxDirections/Match/MBMatch.swift
@@ -22,7 +22,8 @@ open class Match: DirectionsResult {
      - parameter tracepoints: An array of `Tracepoint` that the match found in order.
      - parameter matchOptions: The `MatchOptions` used to create the request.
     */
-    @objc public convenience init(json: [String: Any], tracepoints: [Tracepoint], waypointIndices: IndexSet, matchOptions: MatchOptions) {
+    @objc(initWithJSON:tracepoints:waypointIndices:matchOptions:)
+    public convenience init(json: [String: Any], tracepoints: [Tracepoint], waypointIndices: IndexSet, matchOptions: MatchOptions) {
         let legInfo = zip(zip(tracepoints.prefix(upTo: tracepoints.endIndex - 1), tracepoints.suffix(from: 1)),
                           json["legs"] as? [JSONDictionary] ?? [])
         let legs = legInfo.map { (endpoints, json) -> RouteLeg in

--- a/MapboxDirections/Match/MBMatchOptions.swift
+++ b/MapboxDirections/Match/MBMatchOptions.swift
@@ -15,14 +15,20 @@ open class MatchOptions: DirectionsOptions {
      - parameter location: An array of `CLLocation` objects representing locations the route should try to match the road network against. The array should contain at least two locations (the source and destination) and at most 25 waypoints. (Some profiles, such as `MBDirectionsProfileIdentifierAutomobileAvoidingTraffic`, [may have lower limits](https://www.mapbox.com/api-documentation/#directions).)
      - parameter profileIdentifier: A string specifying the primary mode of transportation for the routes. This parameter, if set, should be set to `MBDirectionsProfileIdentifierAutomobile`, `MBDirectionsProfileIdentifierAutomobileAvoidingTraffic`, `MBDirectionsProfileIdentifierCycling`, or `MBDirectionsProfileIdentifierWalking`. `MBDirectionsProfileIdentifierAutomobile` is used by default.
      */
-    public convenience init(locations: [CLLocation], profileIdentifier: MBDirectionsProfileIdentifier? = nil) {
+    @objc public convenience init(locations: [CLLocation], profileIdentifier: MBDirectionsProfileIdentifier? = nil) {
         let waypoints = locations.map {
             Waypoint(location: $0)
         }
         self.init(waypoints: waypoints, profileIdentifier: profileIdentifier)
     }
     
-    public convenience init(coordinates: [CLLocationCoordinate2D], profileIdentifier: MBDirectionsProfileIdentifier? = nil) {
+    /**
+     Initializes a match options object for matching geographic coordinates against the road network.
+     
+     - parameter coordinates: An array of geographic coordinates representing locations to attempt to match against the road network. The array should contain at least two locations (the source and destination) and at most 25 locations. (Some profiles, such as `MBDirectionsProfileIdentifierAutomobileAvoidingTraffic`, [may have lower limits](https://www.mapbox.com/api-documentation/#directions).) Each coordinate is converted into a `Waypoint` object.
+     - parameter profileIdentifier: A string specifying the primary mode of transportation for the routes. This parameter, if set, should be set to `MBDirectionsProfileIdentifierAutomobile`, `MBDirectionsProfileIdentifierAutomobileAvoidingTraffic`, `MBDirectionsProfileIdentifierCycling`, or `MBDirectionsProfileIdentifierWalking`. `MBDirectionsProfileIdentifierAutomobile` is used by default.
+     */
+    @objc public convenience init(coordinates: [CLLocationCoordinate2D], profileIdentifier: MBDirectionsProfileIdentifier? = nil) {
         let waypoints = coordinates.map {
             Waypoint(coordinate: $0)
         }

--- a/MapboxDirections/Match/MBMatchOptions.swift
+++ b/MapboxDirections/Match/MBMatchOptions.swift
@@ -12,7 +12,7 @@ open class MatchOptions: DirectionsOptions {
     /**
      Initializes a match options object for matching locations against the road network.
      
-     - parameter location: An array of `CLLocation` objects representing locations the route should try to match the road network against. The array should contain at least two locations (the source and destination) and at most 25 waypoints. (Some profiles, such as `MBDirectionsProfileIdentifierAutomobileAvoidingTraffic`, [may have lower limits](https://www.mapbox.com/api-documentation/#directions).)
+     - parameter locations: An array of `CLLocation` objects representing locations to attempt to match against the road network. The array should contain at least two locations (the source and destination) and at most 25 locations. (Some profiles, such as `MBDirectionsProfileIdentifierAutomobileAvoidingTraffic`, [may have lower limits](https://www.mapbox.com/api-documentation/#directions).)
      - parameter profileIdentifier: A string specifying the primary mode of transportation for the routes. This parameter, if set, should be set to `MBDirectionsProfileIdentifierAutomobile`, `MBDirectionsProfileIdentifierAutomobileAvoidingTraffic`, `MBDirectionsProfileIdentifierCycling`, or `MBDirectionsProfileIdentifierWalking`. `MBDirectionsProfileIdentifierAutomobile` is used by default.
      */
     @objc public convenience init(locations: [CLLocation], profileIdentifier: MBDirectionsProfileIdentifier? = nil) {


### PR DESCRIPTION
Exposed more initializers to Objective-C and ensured that “JSON” is capitalized correctly in those initializers when bridged to Objective-C.

Removed `:nodoc:` from various documentation comments about features that have since been documented as part of the public Directions API. Copyedited existing documentation, clarifying the purpose of various properties, fixing typos argument names, and adding argument documentation for more initializers.

/cc @frederoni @captainbarbosa