### PR TITLE
Changing MBVisualInstructionComponentType.image -> .icon

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -3,3 +3,4 @@
 ## master
 
 * Removed `MBAttributeOpenStreetMapNodeIdentifier, as it is no longer being tracked by the API. This is a breaking change.
+* changed `MBVisualInstructionComponentType.image` to `MBVisualInstructionComponentType.icon`, as the API has change to reflect the possibility of a "Generic Route Shield" icon component being passed back from the service.

--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -3,4 +3,4 @@
 ## master
 
 * Removed `MBAttributeOpenStreetMapNodeIdentifier, as it is no longer being tracked by the API. This is a breaking change.
-* changed `MBVisualInstructionComponentType.image` to `MBVisualInstructionComponentType.icon`, as the API has change to reflect the possibility of a "Generic Route Shield" icon component being passed back from the service.
+* changed `MBVisualInstructionComponentType.image` to `MBVisualInstructionComponentType.icon`, as the API has changed to reflect the possibility of a "Generic Route Shield" icon component being passed back from the service.

--- a/MapboxDirections/MBVisualInstructionType.swift
+++ b/MapboxDirections/MBVisualInstructionType.swift
@@ -19,9 +19,9 @@ public enum VisualInstructionComponentType: Int, CustomStringConvertible {
     case text
     
     /**
-     Component contains an image that should be rendered.
+     Component either contains an image that should be rendered, or text that should be rendered as a generic icon.
      */
-    case image
+    case icon
     
     /**
      The compoment contains the localized word for "exit".
@@ -41,7 +41,7 @@ public enum VisualInstructionComponentType: Int, CustomStringConvertible {
         case "delimiter":
             type = .delimiter
         case "icon":
-            type = .image
+            type = .icon
         case "text":
             type = .text
         case "exit":
@@ -58,7 +58,7 @@ public enum VisualInstructionComponentType: Int, CustomStringConvertible {
         switch self {
         case .delimiter:
             return "delimiter"
-        case .image:
+        case .icon:
             return "icon"
         case .text:
             return "text"


### PR DESCRIPTION
Updating `MBVisualInstructionComponentType` to reflect new changes on API. This is to reflect that the icon component may have only text, and thus should be rendered as a generic route shield. Supports mapbox/mapbox-navigation-ios#1190.

/cc @mapbox/navigation-ios 