### PR TITLE
Exposed routes as JSON in RouteCompletionHandler

### DIFF
--- a/Directions Example/ViewController.swift
+++ b/Directions Example/ViewController.swift
@@ -76,7 +76,7 @@ class ViewController: UIViewController, MBDrawingViewDelegate {
             ])
         options.includesSteps = true
         
-        Directions(accessToken: MapboxAccessToken).calculate(options) { (waypoints, routes, error) in
+        Directions(accessToken: MapboxAccessToken).calculate(options) { (waypoints, routes, JSONRoutes, error) in
             guard error == nil else {
                 print("Error calculating directions: \(error!)")
                 return

--- a/MapboxDirections/MBDirections.swift
+++ b/MapboxDirections/MBDirections.swift
@@ -103,7 +103,7 @@ open class Directions: NSObject {
         If the request was canceled or there was an error obtaining the routes, this parameter is `nil`. This is not to be confused with the situation in which no results were found, in which case the array is present but empty.
      - parameter error: The error that occurred, or `nil` if the placemarks were obtained successfully.
      */
-    public typealias RouteCompletionHandler = (_ waypoints: [Waypoint]?, _ routes: [Route]?, _ error: NSError?) -> Void
+    public typealias RouteCompletionHandler = (_ waypoints: [Waypoint]?, _ routes: [Route]?, _ JSONRoutes: [[String: Any]]?, _ error: NSError?) -> Void
     
     /**
      A closure (block) to be called when a map matching request is complete.
@@ -183,9 +183,9 @@ open class Directions: NSObject {
                     route.routeIdentifier = json["uuid"] as? String
                 }
             }
-            completionHandler(response.0, response.1, nil)
+            completionHandler(response.0, response.1, response.2, nil)
         }) { (error) in
-            completionHandler(nil, nil, error)
+            completionHandler(nil, nil, nil, error)
         }
         task.resume()
         return task
@@ -233,9 +233,9 @@ open class Directions: NSObject {
                     route.routeIdentifier = json["uuid"] as? String
                 }
             }
-            completionHandler(response.0, response.1, nil)
+            completionHandler(response.0, response.1, response.2, nil)
         }) { (error) in
-            completionHandler(nil, nil, error)
+            completionHandler(nil, nil, nil, error)
         }
         task.resume()
         return task

--- a/MapboxDirections/MBDirections.swift
+++ b/MapboxDirections/MBDirections.swift
@@ -101,6 +101,9 @@ open class Directions: NSObject {
      - parameter routes: An array of `Route` objects. The preferred route is first; any alternative routes come next if the `RouteOptions` object’s `includesAlternativeRoutes` property was set to `true`. The preferred route depends on the route options object’s `profileIdentifier` property.
         
         If the request was canceled or there was an error obtaining the routes, this parameter is `nil`. This is not to be confused with the situation in which no results were found, in which case the array is present but empty.
+     - parameter JSONRoutes: An array of [String: Any] dictionaries. This exposes a collection of routes in a JSON format within the RouteCompletionHandler tuple.
+     
+        If the request was canceled or there was an error obtaining the routes, this parameter may be `nil`.
      - parameter error: The error that occurred, or `nil` if the placemarks were obtained successfully.
      */
     public typealias RouteCompletionHandler = (_ waypoints: [Waypoint]?, _ routes: [Route]?, _ JSONRoutes: [[String: Any]]?, _ error: NSError?) -> Void

--- a/MapboxDirections/MBRouteOptions.swift
+++ b/MapboxDirections/MBRouteOptions.swift
@@ -153,7 +153,7 @@ open class RouteOptions: DirectionsOptions {
      - parameter json: The API response in JSON dictionary format.
      - returns: A tuple containing an array of waypoints and an array of routes.
      */
-    internal func response(from json: JSONDictionary) -> ([Waypoint]?, [Route]?) {
+    internal func response(from json: JSONDictionary) -> ([Waypoint]?, [Route]?, [[String: Any]]?) {
         var namedWaypoints: [Waypoint]?
         if let jsonWaypoints = (json["waypoints"] as? [JSONDictionary]) {
             namedWaypoints = zip(jsonWaypoints, self.waypoints).map { (api, local) -> Waypoint in
@@ -167,10 +167,12 @@ open class RouteOptions: DirectionsOptions {
         
         let waypoints = namedWaypoints ?? self.waypoints
         
-        let routes = (json["routes"] as? [JSONDictionary])?.map {
+        let JSONRoutes = (json["routes"] as? [JSONDictionary])
+        
+        let routes = JSONRoutes?.map {
             Route(json: $0, waypoints: waypoints, routeOptions: self)
         }
-        return (waypoints, routes)
+        return (waypoints, routes, JSONRoutes)
     }
     
     override public class var supportsSecureCoding: Bool {
@@ -248,15 +250,16 @@ open class RouteOptionsV4: RouteOptions {
         ]
     }
 
-    override func response(from json: JSONDictionary) -> ([Waypoint]?, [Route]?) {
+    override func response(from json: JSONDictionary) -> ([Waypoint]?, [Route]?, [[String: Any]]?) {
         let sourceWaypoint = Waypoint(geoJSON: json["origin"] as! JSONDictionary)!
         let destinationWaypoint = Waypoint(geoJSON: json["destination"] as! JSONDictionary)!
         let intermediateWaypoints = (json["waypoints"] as! [JSONDictionary]).compactMap { Waypoint(geoJSON: $0) }
         let waypoints = [sourceWaypoint] + intermediateWaypoints + [destinationWaypoint]
-        let routes = (json["routes"] as? [JSONDictionary])?.map {
+        let JSONRoutes = (json["routes"] as? [[String: Any]])
+        let routes = JSONRoutes?.map {
             RouteV4(json: $0, waypoints: waypoints, routeOptions: self)
         }
-        return (waypoints, routes)
+        return (waypoints, routes, JSONRoutes)
     }
 }
 

--- a/MapboxDirections/Match/MBMatchOptions.swift
+++ b/MapboxDirections/Match/MBMatchOptions.swift
@@ -131,7 +131,7 @@ open class MatchOptions: DirectionsOptions {
      - parameter json: The API response in JSON dictionary format.
      - returns: A tuple containing an array of waypoints and an array of routes.
      */
-    internal func response(containingRoutesFrom json: JSONDictionary) -> ([Waypoint]?, [Route]?) {
+    internal func response(containingRoutesFrom json: JSONDictionary) -> ([Waypoint]?, [Route]?, [[String: Any]]?) {
 
         var namedWaypoints: [Waypoint]?
         if let jsonWaypoints = (json["tracepoints"] as? [JSONDictionary]) {
@@ -157,10 +157,12 @@ open class MatchOptions: DirectionsOptions {
             }
         }
         
-        let routes = (json["matchings"] as? [JSONDictionary])?.map {
+        let JSONRoutes = (json["matchings"] as? [JSONDictionary])
+        
+        let routes = JSONRoutes?.map {
             Route(json: $0, waypoints: filteredWaypoints ?? waypoints, routeOptions: opts)
         }
         
-        return (waypoints, routes)
+        return (waypoints, routes, JSONRoutes)
     }
 }


### PR DESCRIPTION
This exposes a third argument in the `RouteCompletionHandler` tuple; `JSONRoutes`. This represents the returned routes in an array of `[String: Any]` dictionaries. 

Addresses https://github.com/mapbox/mapbox-navigation-ios/pull/1496