### PR TITLE
Revert "Add allowsArrivingOnOppositeSide DirectionsOptions bool"

### DIFF
--- a/MapboxDirections/MBDirectionsOptions.swift
+++ b/MapboxDirections/MBDirectionsOptions.swift
@@ -220,7 +220,6 @@ open class DirectionsOptions: NSObject, NSSecureCoding, NSCopying {
         copy.includesSpokenInstructions = includesSpokenInstructions
         copy.distanceMeasurementSystem = distanceMeasurementSystem
         copy.includesVisualInstructions = includesVisualInstructions
-        copy.allowsArrivingOnOppositeSide = allowsArrivingOnOppositeSide
         return copy
     }
     
@@ -243,8 +242,7 @@ open class DirectionsOptions: NSObject, NSSecureCoding, NSCopying {
             locale == other.locale,
             includesSpokenInstructions == other.includesSpokenInstructions,
             includesVisualInstructions == other.includesVisualInstructions,
-            distanceMeasurementSystem == other.distanceMeasurementSystem,
-            allowsArrivingOnOppositeSide == other.allowsArrivingOnOppositeSide else { return false }
+            distanceMeasurementSystem == other.distanceMeasurementSystem else { return false }
         return true
     }
     
@@ -259,7 +257,6 @@ open class DirectionsOptions: NSObject, NSSecureCoding, NSCopying {
         coder.encode(includesSpokenInstructions, forKey: "includesSpokenInstructions")
         coder.encode(distanceMeasurementSystem.description, forKey: "distanceMeasurementSystem")
         coder.encode(includesVisualInstructions, forKey: "includesVisualInstructions")
-        coder.encode(allowsArrivingOnOppositeSide, forKey: "allowsArrivingOnOppositeSide")
     }
     
     public required init?(coder decoder: NSCoder) {
@@ -303,8 +300,6 @@ open class DirectionsOptions: NSObject, NSSecureCoding, NSCopying {
         }
         
         includesVisualInstructions = decoder.decodeBool(forKey: "includesVisualInstructions")
-        
-        allowsArrivingOnOppositeSide = decoder.decodeBool(forKey: "allowsArrivingOnOppositeSide")
     }
     
     /**
@@ -410,13 +405,6 @@ open class DirectionsOptions: NSObject, NSSecureCoding, NSCopying {
     @objc open var includesVisualInstructions = false
     
     /**
-     A Boolean value that indicates whether each of the resulting routes must approach a waypoint from the same side of the road.
-     
-     By default, the route can approach a waypoint from either side of the road. If set to false, the route will be returned so that on arrival, the waypoint will be found on the side that corresponds with the `DrivingSide` of the region in which the returned route is located.
-     */
-    @objc open var allowsArrivingOnOppositeSide: Bool = true
-    
-    /**
      An array of URL parameters to include in the request URL.
      */
     internal var params: [URLQueryItem] {
@@ -460,8 +448,6 @@ open class DirectionsOptions: NSObject, NSSecureCoding, NSCopying {
             let names = waypoints.map { $0.name ?? "" }.joined(separator: ";")
             params.append(URLQueryItem(name: "waypoint_names", value: names))
         }
-        
-        params.append(URLQueryItem(name: "approaches", value: allowsArrivingOnOppositeSide ? "unrestricted" : "curb"))
         
         return params
     }

--- a/MapboxDirections/MBRouteOptions.swift
+++ b/MapboxDirections/MBRouteOptions.swift
@@ -49,7 +49,6 @@ open class RouteOptions: DirectionsOptions {
         self.locale = matchOptions.locale
         self.includesSpokenInstructions = matchOptions.includesSpokenInstructions
         self.includesVisualInstructions = matchOptions.includesVisualInstructions
-        self.allowsArrivingOnOppositeSide = matchOptions.allowsArrivingOnOppositeSide
     }
 
     public required init?(coder decoder: NSCoder) {

--- a/MapboxDirectionsTests/RouteOptionsTests.swift
+++ b/MapboxDirectionsTests/RouteOptionsTests.swift
@@ -34,7 +34,6 @@ class RouteOptionsTests: XCTestCase {
         XCTAssertEqual(unarchivedOptions.distanceMeasurementSystem, options.distanceMeasurementSystem)
         XCTAssertEqual(unarchivedOptions.includesVisualInstructions, options.includesVisualInstructions)
         XCTAssertEqual(unarchivedOptions.roadClassesToAvoid, options.roadClassesToAvoid)
-        XCTAssertEqual(unarchivedOptions.allowsArrivingOnOppositeSide, options.allowsArrivingOnOppositeSide)
     }
     func testCopying() {
         let testInstance = RouteOptions.testInstance
@@ -103,7 +102,6 @@ private extension RouteOptions {
         opts.distanceMeasurementSystem = .metric
         opts.includesVisualInstructions = true
         opts.roadClassesToAvoid = .toll
-        opts.allowsArrivingOnOppositeSide = true
         
         return opts
     }


### PR DESCRIPTION
Reverts mapbox/MapboxDirections.swift#257

This needs to be reverted. For every waypoint in a request, there needs to be just as many "approaches". Right now, this only adds a single element.

/cc @1ec5 