### PR TITLE
Fix compiler warnings

### DIFF
--- a/MapboxDirections/MBDirections.swift
+++ b/MapboxDirections/MBDirections.swift
@@ -121,7 +121,7 @@ open class Directions: NSObject {
      To use this object, a Mapbox [access token](https://www.mapbox.com/help/define-access-token/) should be specified in the `MGLMapboxAccessToken` key in the main application bundle’s Info.plist.
      */
     @objc(sharedDirections)
-    open static let shared = Directions(accessToken: nil)
+    public static let shared = Directions(accessToken: nil)
     
     /// The API endpoint to request the directions from.
     internal var apiEndpoint: URL

--- a/MapboxDirections/MBDirectionsResult.swift
+++ b/MapboxDirections/MBDirectionsResult.swift
@@ -68,7 +68,7 @@ open class DirectionsResult: NSObject, NSSecureCoding {
      
      Using the [Mapbox Maps SDK for iOS](https://www.mapbox.com/ios-sdk/) or [Mapbox Maps SDK for macOS](https://github.com/mapbox/mapbox-gl-native/tree/master/platform/macos/), you can create an `MGLPolyline` object using these coordinates to display an overview of the route on an `MGLMapView`.
      */
-    @objc open let coordinates: [CLLocationCoordinate2D]?
+    @objc public let coordinates: [CLLocationCoordinate2D]?
     
     /**
      The number of coordinates.
@@ -107,7 +107,7 @@ open class DirectionsResult: NSObject, NSSecureCoding {
      
      To determine the name of the route, concatenate the names of the route’s legs.
      */
-    @objc open let legs: [RouteLeg]
+    @objc public let legs: [RouteLeg]
     
     @objc open override var description: String {
         return legs.map { $0.name }.joined(separator: " – ")
@@ -120,7 +120,7 @@ open class DirectionsResult: NSObject, NSSecureCoding {
      
      The value of this property accounts for the distance that the user must travel to traverse the path of the route. It is the sum of the `distance` properties of the route’s legs, not the sum of the direct distances between the route’s waypoints. You should not assume that the user would travel along this distance at a fixed speed.
      */
-    @objc open let distance: CLLocationDistance
+    @objc public let distance: CLLocationDistance
     
     /**
      The route’s expected travel time, measured in seconds.
@@ -129,14 +129,14 @@ open class DirectionsResult: NSObject, NSSecureCoding {
      
      Do not assume that the user would travel along the route at a fixed speed. For more granular travel times, use the `RouteLeg.expectedTravelTime` or `RouteStep.expectedTravelTime`. For even more granularity, specify the `AttributeOptions.expectedTravelTime` option and use the `RouteLeg.expectedSegmentTravelTimes` property.
      */
-    @objc open let expectedTravelTime: TimeInterval
+    @objc public let expectedTravelTime: TimeInterval
     
     /**
      `RouteOptions` used to create the directions request.
      
      The route options object’s profileIdentifier property reflects the primary mode of transportation used for the route. Individual steps along the route might use different modes of transportation as necessary.
      */
-    @objc open let directionsOptions: DirectionsOptions
+    @objc public let directionsOptions: DirectionsOptions
     
     /**
      The [access token](https://www.mapbox.com/help/define-access-token/) used to make the directions request.

--- a/MapboxDirections/MBIntersection.swift
+++ b/MapboxDirections/MBIntersection.swift
@@ -123,7 +123,7 @@ public class Intersection: NSObject, NSSecureCoding {
         self.outletRoadClasses = outletRoadClasses
     }
     
-    open static var supportsSecureCoding = true
+    public static var supportsSecureCoding = true
     
     @objc public func encode(with coder: NSCoder) {
         coder.encode([

--- a/MapboxDirections/MBLane.swift
+++ b/MapboxDirections/MBLane.swift
@@ -31,7 +31,7 @@ public class Lane: NSObject, NSSecureCoding {
         self.indications = indications
     }
     
-    open static var supportsSecureCoding = true
+    public static var supportsSecureCoding = true
     
     public func encode(with coder: NSCoder) {
         coder.encode(indications.description.components(separatedBy: ","), forKey: "indications")

--- a/MapboxDirections/MBRouteLeg.swift
+++ b/MapboxDirections/MBRouteLeg.swift
@@ -95,7 +95,7 @@ open class RouteLeg: NSObject, NSSecureCoding {
         segmentCongestionLevels = decoder.decodeObject(of: [NSArray.self, NSNumber.self], forKey: "segmentCongestionLevels") as? [CongestionLevel]
     }
     
-    @objc open static var supportsSecureCoding = true
+    @objc public static var supportsSecureCoding = true
     
     public func encode(with coder: NSCoder) {
         coder.encode(source, forKey: "source")
@@ -118,14 +118,14 @@ open class RouteLeg: NSObject, NSSecureCoding {
      
      Unless this is the first leg of the route, the source of this leg is the same as the destination of the previous leg.
      */
-    @objc open let source: Waypoint
+    @objc public let source: Waypoint
     
     /**
      The endpoint of the route leg.
      
      Unless this is the last leg of the route, the destination of this leg is the same as the source of the next leg.
      */
-    @objc open let destination: Waypoint
+    @objc public let destination: Waypoint
     
     /**
      An array of one or more `RouteStep` objects representing the steps for traversing this leg of the route.
@@ -134,7 +134,7 @@ open class RouteLeg: NSObject, NSSecureCoding {
      
      This array is empty if the `includesSteps` property of the original `RouteOptions` object is set to `false`.
      */
-    @objc open let steps: [RouteStep]
+    @objc public let steps: [RouteStep]
     
     
     /**
@@ -142,7 +142,7 @@ open class RouteLeg: NSObject, NSSecureCoding {
      
      This property is set if the `RouteOptions.attributeOptions` property contains `.distance`.
      */
-    @objc open let segmentDistances: [CLLocationDistance]?
+    @objc public let segmentDistances: [CLLocationDistance]?
     
     /**
      An array containing the expected travel time (measured in seconds) between each coordinate in the route leg geometry.
@@ -151,7 +151,7 @@ open class RouteLeg: NSObject, NSSecureCoding {
      
      This property is set if the `RouteOptions.attributeOptions` property contains `.expectedTravelTime`.
      */
-    @objc open let expectedSegmentTravelTimes: [TimeInterval]?
+    @objc public let expectedSegmentTravelTimes: [TimeInterval]?
     
     /**
      An array containing the expected average speed (measured in meters per second) between each coordinate in the route leg geometry.
@@ -160,7 +160,7 @@ open class RouteLeg: NSObject, NSSecureCoding {
      
      This property is set if the `RouteOptions.attributeOptions` property contains `.speed`.
      */
-    @objc open let segmentSpeeds: [CLLocationSpeed]?
+    @objc public let segmentSpeeds: [CLLocationSpeed]?
     
     /**
      An array containing the traffic congestion level along each road segment in the route leg geometry.
@@ -171,7 +171,7 @@ open class RouteLeg: NSObject, NSSecureCoding {
      
      This property is set if the `RouteOptions.attributeOptions` property contains `.congestionLevel`.
      */
-    open let segmentCongestionLevels: [CongestionLevel]?
+    public let segmentCongestionLevels: [CongestionLevel]?
     
     // MARK: Getting Additional Leg Details
     
@@ -182,7 +182,7 @@ open class RouteLeg: NSObject, NSSecureCoding {
      
      The leg’s name does not identify the start and end points of the leg. To distinguish one leg from another within the same route, concatenate the `name` properties of the `source` and `destination` waypoints.
      */
-    @objc open let name: String
+    @objc public let name: String
     
     @objc open override var description: String {
         return name
@@ -193,7 +193,7 @@ open class RouteLeg: NSObject, NSSecureCoding {
      
      The value of this property accounts for the distance that the user must travel to arrive at the destination from the source. It is not the direct distance between the source and destination, nor should not assume that the user would travel along this distance at a fixed speed.
      */
-    @objc open let distance: CLLocationDistance
+    @objc public let distance: CLLocationDistance
     
     /**
      The route leg’s expected travel time, measured in seconds.
@@ -202,14 +202,14 @@ open class RouteLeg: NSObject, NSSecureCoding {
      
      Do not assume that the user would travel along the leg at a fixed speed. For the expected travel time on each individual segment along the leg, use the `RouteStep.expectedTravelTimes` property. For more granularity, specify the `AttributeOptions.expectedTravelTime` option and use the `expectedSegmentTravelTimes` property.
      */
-    @objc open let expectedTravelTime: TimeInterval
+    @objc public let expectedTravelTime: TimeInterval
     
     /**
      A string specifying the primary mode of transportation for the route leg.
      
      The value of this property is `MBDirectionsProfileIdentifierAutomobile`, `MBDirectionsProfileIdentifierAutomobileAvoidingTraffic`, `MBDirectionsProfileIdentifierCycling`, or `MBDirectionsProfileIdentifierWalking`, depending on the `profileIdentifier` property of the original `RouteOptions` object. This property reflects the primary mode of transportation used for the route leg. Individual steps along the route leg might use different modes of transportation as necessary.
      */
-    @objc open let profileIdentifier: MBDirectionsProfileIdentifier
+    @objc public let profileIdentifier: MBDirectionsProfileIdentifier
     
     func debugQuickLookObject() -> Any? {
         let coordinates = steps.reduce([], { $0 + ($1.coordinates ?? []) })

--- a/MapboxDirections/MBRouteStep.swift
+++ b/MapboxDirections/MBRouteStep.swift
@@ -702,7 +702,7 @@ open class RouteStep: NSObject, NSSecureCoding {
         instructionsDisplayedAlongStep = decoder.decodeObject(of: [NSArray.self, VisualInstructionBanner.self], forKey: "instructionsDisplayedAlongStep") as? [VisualInstructionBanner]
     }
     
-    open static var supportsSecureCoding = true
+    public static var supportsSecureCoding = true
     
     public func encode(with coder: NSCoder) {
         let coordinateDictionaries = coordinates?.map { [
@@ -759,7 +759,7 @@ open class RouteStep: NSObject, NSSecureCoding {
      
      Using the [Mapbox Maps SDK for iOS](https://www.mapbox.com/ios-sdk/) or [Mapbox Maps SDK for macOS](https://github.com/mapbox/mapbox-gl-native/tree/master/platform/macos/), you can create an `MGLPolyline` object using these coordinates to display a portion of a route on an `MGLMapView`.
      */
-    @objc open let coordinates: [CLLocationCoordinate2D]?
+    @objc public let coordinates: [CLLocationCoordinate2D]?
     
     /**
      The number of coordinates.
@@ -806,7 +806,7 @@ open class RouteStep: NSObject, NSSecureCoding {
      
      - note: If you use MapboxDirections.swift with the Mapbox Directions API, this property is formatted and localized for display to the user. If you use OSRM directly, this property contains a basic string that only includes the maneuver type and direction. Use [OSRM Text Instructions](https://github.com/Project-OSRM/osrm-text-instructions.swift/) to construct a complete, localized instruction string for display.
      */
-    @objc open let instructions: String
+    @objc public let instructions: String
     
     /**
      Instructions about the next step’s maneuver, optimized for speech synthesis.
@@ -815,7 +815,7 @@ open class RouteStep: NSObject, NSSecureCoding {
      
      This property is non-`nil` if the `RouteOptions.includesSpokenInstructions` option is set to `true`. For instructions designed for display, use the `instructions` property.
      */
-    @objc open let instructionsSpokenAlongStep: [SpokenInstruction]?
+    @objc public let instructionsSpokenAlongStep: [SpokenInstruction]?
     
     /**
      Instructions about the next step’s maneuver, optimized for display in real time.
@@ -824,7 +824,7 @@ open class RouteStep: NSObject, NSSecureCoding {
      
      This property is non-`nil` if the `RouteOptions.includesVisualInstructions` option is set to `true`. For instructions designed for speech synthesis, use the `instructionsSpokenAlongStep` property. For instructions designed for display in a static list, use the `instructions` property.
      */
-    @objc open let instructionsDisplayedAlongStep: [VisualInstructionBanner]?
+    @objc public let instructionsDisplayedAlongStep: [VisualInstructionBanner]?
     
     @objc open override var description: String {
         return instructions
@@ -833,34 +833,34 @@ open class RouteStep: NSObject, NSSecureCoding {
     /**
      The user’s heading immediately before performing the maneuver.
      */
-    open let initialHeading: CLLocationDirection?
+    public let initialHeading: CLLocationDirection?
     
     /**
      The user’s heading immediately after performing the maneuver.
      
      The value of this property may differ from the user’s heading after traveling along the road past the maneuver.
      */
-    open let finalHeading: CLLocationDirection?
+    public let finalHeading: CLLocationDirection?
     
     /**
      The type of maneuver required for beginning this step.
      */
-    @objc open let maneuverType: ManeuverType
+    @objc public let maneuverType: ManeuverType
     
     /**
      Additional directional information to clarify the maneuver type.
      */
-    @objc open let maneuverDirection: ManeuverDirection
+    @objc public let maneuverDirection: ManeuverDirection
     
     /**
      Which side of a bidirectional road the driver should drive on, also known as the rule of the road.
      */
-    open let drivingSide: DrivingSide
+    public let drivingSide: DrivingSide
     
     /**
      The location of the maneuver at the beginning of this step.
      */
-    @objc open let maneuverLocation: CLLocationCoordinate2D
+    @objc public let maneuverLocation: CLLocationCoordinate2D
     
     /**
      The number of exits from the previous maneuver up to and including this step’s maneuver.
@@ -869,7 +869,7 @@ open class RouteStep: NSObject, NSSecureCoding {
      
      In some cases, the number of exits leading to a maneuver may be more useful to the user than the distance to the maneuver.
      */
-    open let exitIndex: Int?
+    public let exitIndex: Int?
     
     /**
      Any [exit numbers](https://en.wikipedia.org/wiki/Exit_number) assigned to the highway exit at the maneuver.
@@ -878,7 +878,7 @@ open class RouteStep: NSObject, NSSecureCoding {
      
      An exit number is an alphanumeric identifier posted at or ahead of a highway off-ramp. Exit numbers may increase or decrease sequentially along a road, or they may correspond to distances from either end of the road. An alphabetic suffix may appear when multiple exits are located in the same interchange. If multiple exits are [combined into a single exit](https://en.wikipedia.org/wiki/Local-express_lanes#Example_of_cloverleaf_interchanges), the step may have multiple exit codes.
      */
-    @objc open let exitCodes: [String]?
+    @objc public let exitCodes: [String]?
     
     /**
      The names of the roundabout exit.
@@ -896,7 +896,7 @@ open class RouteStep: NSObject, NSSecureCoding {
      
      The transcription is written in the [International Phonetic Alphabet](https://en.wikipedia.org/wiki/International_Phonetic_Alphabet).
      */
-    @objc open let phoneticExitNames: [String]?
+    @objc public let phoneticExitNames: [String]?
     
     // MARK: Getting Details About the Approach to the Next Maneuver
     
@@ -905,7 +905,7 @@ open class RouteStep: NSObject, NSSecureCoding {
      
      The value of this property accounts for the distance that the user must travel to go from this step’s maneuver location to the next step’s maneuver location. It is not the sum of the direct distances between the route’s waypoints, nor should you assume that the user would travel along this distance at a fixed speed.
      */
-    @objc open let distance: CLLocationDistance
+    @objc public let distance: CLLocationDistance
     
     /**
      The step’s expected travel time, measured in seconds.
@@ -914,7 +914,7 @@ open class RouteStep: NSObject, NSSecureCoding {
      
      Do not assume that the user would travel along the step at a fixed speed. For the expected travel time on each individual segment along the leg, specify the `AttributeOptions.expectedTravelTime` option and use the `RouteLeg.expectedSegmentTravelTimes` property.
      */
-    @objc open let expectedTravelTime: TimeInterval
+    @objc public let expectedTravelTime: TimeInterval
     
     /**
      The names of the road or path leading from this step’s maneuver to the next step’s maneuver.
@@ -923,7 +923,7 @@ open class RouteStep: NSObject, NSSecureCoding {
      
      If the maneuver is a roundabout maneuver, the outlet to take is named in the `exitNames` property; the `names` property is only set for large roundabouts that have their own names.
      */
-    @objc open let names: [String]?
+    @objc public let names: [String]?
     
     /**
      A phonetic or phonemic transcription indicating how to pronounce the names in the `names` property.
@@ -932,7 +932,7 @@ open class RouteStep: NSObject, NSSecureCoding {
      
      If the maneuver traverses a large, named roundabout, the `exitPronunciationHints` property contains a hint about how to pronounce the names of the outlet to take.
      */
-    @objc open let phoneticNames: [String]?
+    @objc public let phoneticNames: [String]?
     
     /**
      Any route reference codes assigned to the road or path leading from this step’s maneuver to the next step’s maneuver.
@@ -941,7 +941,7 @@ open class RouteStep: NSObject, NSSecureCoding {
      
      If a highway ramp is part of a numbered route, its reference code is contained in this property. On the other hand, guide signage for a highway ramp usually indicates route reference codes of the adjoining road; use the `destinationCodes` property for those route reference codes.
      */
-    @objc open let codes: [String]?
+    @objc public let codes: [String]?
     
     // MARK: Getting Additional Step Details
     
@@ -950,7 +950,7 @@ open class RouteStep: NSObject, NSSecureCoding {
      
      This step may use a different mode of transportation than the overall route.
      */
-    @objc open let transportType: TransportType
+    @objc public let transportType: TransportType
     
     /**
      Any route reference codes that appear on guide signage for the road leading from this step’s maneuver to the next step’s maneuver.
@@ -966,7 +966,7 @@ open class RouteStep: NSObject, NSSecureCoding {
      
      This property is typically available in steps leading to or from a freeway or expressway.
      */
-    @objc open let destinations: [String]?
+    @objc public let destinations: [String]?
     
     /**
      An array of intersections along the step.

--- a/MapboxDirections/MBSpokenInstruction.swift
+++ b/MapboxDirections/MBSpokenInstruction.swift
@@ -66,7 +66,7 @@ open class SpokenInstruction: NSObject, NSSecureCoding {
         ssmlText = decoder.decodeObject(of: NSString.self, forKey: "ssmlText")! as String
     }
     
-    open static var supportsSecureCoding = true
+    public static var supportsSecureCoding = true
     
     public func encode(with coder: NSCoder) {
         coder.encode(distanceAlongStep, forKey: "distanceAlongStep")

--- a/MapboxDirections/MBVisualInstruction.swift
+++ b/MapboxDirections/MBVisualInstruction.swift
@@ -6,7 +6,7 @@ import Foundation
 @objc(MBVisualInstruction)
 open class VisualInstruction: NSObject, NSSecureCoding {
     
-    open static var supportsSecureCoding = true
+    public static var supportsSecureCoding = true
     
     /**
      A plain text representation of the instruction.

--- a/MapboxDirections/MBVisualInstructionBanner.swift
+++ b/MapboxDirections/MBVisualInstructionBanner.swift
@@ -94,7 +94,7 @@ open class VisualInstructionBanner: NSObject, NSSecureCoding {
         self.tertiaryInstruction = decoder.decodeObject(of: VisualInstruction.self, forKey: "tertiaryInstruction")
     }
     
-    open static var supportsSecureCoding = true
+    public static var supportsSecureCoding = true
     
     public func encode(with coder: NSCoder) {
         coder.encode(distanceAlongStep, forKey: "distanceAlongStep")

--- a/MapboxDirections/MBWaypoint.swift
+++ b/MapboxDirections/MBWaypoint.swift
@@ -93,7 +93,7 @@ open class Waypoint: NSObject, NSCopying, NSSecureCoding {
     /**
      The geographic coordinate of the waypoint.
      */
-    @objc open let coordinate: CLLocationCoordinate2D
+    @objc public let coordinate: CLLocationCoordinate2D
     
     /**
      The radius of uncertainty for the waypoint, measured in meters.


### PR DESCRIPTION
Static declarations and `let` properties are implicitly marked `final` so switched the access modifier from `open` to `public`.

/cc @JThramer @1ec5 