### PR TITLE
Remove CocoaPods from documentation script

### DIFF
--- a/scripts/document.sh
+++ b/scripts/document.sh
@@ -29,7 +29,6 @@ DEFAULT_THEME="docs/theme"
 THEME=${JAZZY_THEME:-$DEFAULT_THEME}
 
 jazzy \
-    --podspec MapboxDirections.swift.podspec \
     --config docs/jazzy.yml \
     --sdk iphonesimulator \
     --module-version ${VERSION} \


### PR DESCRIPTION
The documentation generation script no longer depends on the podspec. As far as I can tell, the script including the `--podspec` argument was copied from the navigation SDK repository, where CocoaPods is being used to glom the CoreNavigation and MapboxNavigation modules together for interlinking purposes. But that consideration doesn’t apply to this repository.

Fixes #292 by way of removing the CocoaPods dependency.

/cc @frederoni