### PR TITLE
Fix Swift example app build.

### DIFF
--- a/Directions Example/ViewController.swift
+++ b/Directions Example/ViewController.swift
@@ -18,7 +18,7 @@ class ViewController: UIViewController, MBDrawingViewDelegate {
         super.viewDidLoad()
         
         assert(MapboxAccessToken != "<# your Mapbox access token #>", "You must set `MapboxAccessToken` to your Mapbox access token.")
-        MGLAccountManager.setAccessToken(MapboxAccessToken)
+        MGLAccountManager.accessToken = MapboxAccessToken
         
         mapView = MGLMapView(frame: view.bounds)
         mapView.autoresizingMask = [.flexibleWidth, .flexibleHeight]


### PR DESCRIPTION
Hello,

Since this commit (bump of the Mapbox iOS SDK version) c33e1c146b24788b55b794f2bf6c02c87173d24a  the Swift example app cannot build due to a change in the Mapbox API.