### PR TITLE
Coordinate Truncation

### DIFF
--- a/MapboxDirections.xcodeproj/project.pbxproj
+++ b/MapboxDirections.xcodeproj/project.pbxproj
@@ -55,6 +55,9 @@
 		8D381B6C1FDB3D8B008D5A58 /* String.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D381B691FDB101F008D5A58 /* String.swift */; };
 		8D381B6D1FDB3D8B008D5A58 /* String.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D381B691FDB101F008D5A58 /* String.swift */; };
 		8D434679219E1167008B7BF3 /* Double.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D434678219E1167008B7BF3 /* Double.swift */; };
+		8D43467A219E15C3008B7BF3 /* Double.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D434678219E1167008B7BF3 /* Double.swift */; };
+		8D43467B219E15C4008B7BF3 /* Double.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D434678219E1167008B7BF3 /* Double.swift */; };
+		8D43467C219E15C6008B7BF3 /* Double.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D434678219E1167008B7BF3 /* Double.swift */; };
 		AEAB390D20D7F4F4008F4E54 /* subLaneInstructions.json in Resources */ = {isa = PBXBuildFile; fileRef = AEAB390C20D7F4F4008F4E54 /* subLaneInstructions.json */; };
 		AEAB390E20D7F508008F4E54 /* subLaneInstructions.json in Resources */ = {isa = PBXBuildFile; fileRef = AEAB390C20D7F4F4008F4E54 /* subLaneInstructions.json */; };
 		AEAB390F20D7F50A008F4E54 /* subLaneInstructions.json in Resources */ = {isa = PBXBuildFile; fileRef = AEAB390C20D7F4F4008F4E54 /* subLaneInstructions.json */; };
@@ -1211,6 +1214,7 @@
 			files = (
 				C5DAAC9B2019167C001F9261 /* MBMatch.swift in Sources */,
 				35DBF010217E17A30009D2AE /* HTTPURLResponse.swift in Sources */,
+				8D43467A219E15C3008B7BF3 /* Double.swift in Sources */,
 				C52552C61FA162F900B1545C /* MBVisualInstructionComponent.swift in Sources */,
 				C53A02261E92C26E009837BD /* MBAttribute.swift in Sources */,
 				DA1A10C91D00F969009F82FA /* MBRouteLeg.swift in Sources */,
@@ -1268,6 +1272,7 @@
 			files = (
 				C5DAAC9C2019167D001F9261 /* MBMatch.swift in Sources */,
 				35DBF011217E17A30009D2AE /* HTTPURLResponse.swift in Sources */,
+				8D43467B219E15C4008B7BF3 /* Double.swift in Sources */,
 				C52552C71FA162FA00B1545C /* MBVisualInstructionComponent.swift in Sources */,
 				C53A02271E92C26F009837BD /* MBAttribute.swift in Sources */,
 				DA1A10EF1D010247009F82FA /* MBRouteLeg.swift in Sources */,
@@ -1325,6 +1330,7 @@
 			files = (
 				C5DAAC9D2019167E001F9261 /* MBMatch.swift in Sources */,
 				35DBF012217E17A30009D2AE /* HTTPURLResponse.swift in Sources */,
+				8D43467C219E15C6008B7BF3 /* Double.swift in Sources */,
 				C52552C81FA162FB00B1545C /* MBVisualInstructionComponent.swift in Sources */,
 				C53A02281E92C271009837BD /* MBAttribute.swift in Sources */,
 				DA1A11061D0103A3009F82FA /* MBRouteLeg.swift in Sources */,

--- a/MapboxDirections.xcodeproj/project.pbxproj
+++ b/MapboxDirections.xcodeproj/project.pbxproj
@@ -54,6 +54,7 @@
 		8D381B6B1FDB3D8A008D5A58 /* String.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D381B691FDB101F008D5A58 /* String.swift */; };
 		8D381B6C1FDB3D8B008D5A58 /* String.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D381B691FDB101F008D5A58 /* String.swift */; };
 		8D381B6D1FDB3D8B008D5A58 /* String.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D381B691FDB101F008D5A58 /* String.swift */; };
+		8D434679219E1167008B7BF3 /* Double.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D434678219E1167008B7BF3 /* Double.swift */; };
 		AEAB390D20D7F4F4008F4E54 /* subLaneInstructions.json in Resources */ = {isa = PBXBuildFile; fileRef = AEAB390C20D7F4F4008F4E54 /* subLaneInstructions.json */; };
 		AEAB390E20D7F508008F4E54 /* subLaneInstructions.json in Resources */ = {isa = PBXBuildFile; fileRef = AEAB390C20D7F4F4008F4E54 /* subLaneInstructions.json */; };
 		AEAB390F20D7F50A008F4E54 /* subLaneInstructions.json in Resources */ = {isa = PBXBuildFile; fileRef = AEAB390C20D7F4F4008F4E54 /* subLaneInstructions.json */; };
@@ -310,6 +311,7 @@
 		8D381B601FD9F5B1008D5A58 /* noDestinationName.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = noDestinationName.json; sourceTree = "<group>"; };
 		8D381B621FDB01D1008D5A58 /* apiDestinationName.json */ = {isa = PBXFileReference; explicitFileType = text.json; path = apiDestinationName.json; sourceTree = "<group>"; };
 		8D381B691FDB101F008D5A58 /* String.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = String.swift; sourceTree = "<group>"; };
+		8D434678219E1167008B7BF3 /* Double.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Double.swift; sourceTree = "<group>"; };
 		AEAB390C20D7F4F4008F4E54 /* subLaneInstructions.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = subLaneInstructions.json; sourceTree = "<group>"; };
 		AEAB391020D94699008F4E54 /* subVisualInstructions.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = subVisualInstructions.json; sourceTree = "<group>"; };
 		AEDC211820B5DBDE0052DED8 /* MBLaneIndicationComponent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MBLaneIndicationComponent.swift; sourceTree = "<group>"; };
@@ -513,6 +515,7 @@
 				8D381B691FDB101F008D5A58 /* String.swift */,
 				C582BA2D2073ED6300647DAA /* Array.swift */,
 				35DBF009217E172C0009D2AE /* CLLocationCoordinate2D.swift */,
+				8D434678219E1167008B7BF3 /* Double.swift */,
 				35DBF00E217E17A30009D2AE /* HTTPURLResponse.swift */,
 			);
 			path = Extensions;
@@ -1360,6 +1363,7 @@
 			files = (
 				C51538CC1E807FF00093FF3E /* MBAttribute.swift in Sources */,
 				35DBF00F217E17A30009D2AE /* HTTPURLResponse.swift in Sources */,
+				8D434679219E1167008B7BF3 /* Double.swift in Sources */,
 				DA2E03EB1CB0E13D00D1269A /* MBRouteOptions.swift in Sources */,
 				C582BA2E2073ED6300647DAA /* Array.swift in Sources */,
 				C52552B91FA15D5900B1545C /* MBVisualInstructionBanner.swift in Sources */,

--- a/MapboxDirections/Extensions/Double.swift
+++ b/MapboxDirections/Extensions/Double.swift
@@ -1,0 +1,5 @@
+extension Double {
+    func rounded(to precision: Double) -> Double {
+        return (self * precision).rounded() / precision
+    }
+}

--- a/MapboxDirections/MBDirectionsOptions.swift
+++ b/MapboxDirections/MBDirectionsOptions.swift
@@ -328,8 +328,7 @@ open class DirectionsOptions: NSObject, NSSecureCoding, NSCopying {
      An array of directions query strings to include in the request URL.
      */
     internal var queries: [String] {
-        let precision: Waypoint.CoordinatePrecision = shapeFormat == .polyline ? .five : .six
-        return waypoints.compactMap { return $0.jsonRepresentation(precision: precision) }
+        return waypoints.compactMap { return "\($0.coordinate.longitude.rounded(to: 1e6)),\($0.coordinate.latitude.rounded(to: 1e6))" }
     }
     
     internal var path: String {

--- a/MapboxDirections/MBDirectionsOptions.swift
+++ b/MapboxDirections/MBDirectionsOptions.swift
@@ -328,7 +328,8 @@ open class DirectionsOptions: NSObject, NSSecureCoding, NSCopying {
      An array of directions query strings to include in the request URL.
      */
     internal var queries: [String] {
-        return waypoints.map { "\($0.coordinate.longitude),\($0.coordinate.latitude)" }
+        let precision: Waypoint.CoordinatePrecision = shapeFormat == .polyline ? .five : .six
+        return waypoints.compactMap { return $0.jsonRepresentation(precision: precision) }
     }
     
     internal var path: String {

--- a/MapboxDirections/MBWaypoint.swift
+++ b/MapboxDirections/MBWaypoint.swift
@@ -106,6 +106,24 @@ open class Waypoint: NSObject, NSCopying, NSSecureCoding {
      */
     @objc open var coordinateAccuracy: CLLocationAccuracy = -1
     
+    internal enum CoordinatePrecision: Int {
+        case five = 5
+        case six = 6
+     }
+    
+    internal func jsonRepresentation(precision: CoordinatePrecision) -> String? {
+        let formatter = NumberFormatter()
+        formatter.maximumFractionDigits = precision.rawValue
+        
+        guard let lat = formatter.string(for: coordinate.latitude),
+            let long = formatter.string(for: coordinate.longitude) else {
+                return nil
+        }
+        
+        return "\(long),\(lat)"
+    }
+    
+    
     // MARK: Getting the Direction of Approach
     
     /**

--- a/MapboxDirections/MBWaypoint.swift
+++ b/MapboxDirections/MBWaypoint.swift
@@ -111,17 +111,6 @@ open class Waypoint: NSObject, NSCopying, NSSecureCoding {
         case six = 6
      }
     
-    internal func jsonRepresentation(precision: CoordinatePrecision) -> String? {
-        let formatter = NumberFormatter()
-        formatter.maximumFractionDigits = precision.rawValue
-        
-        guard let lat = formatter.string(for: coordinate.latitude),
-            let long = formatter.string(for: coordinate.longitude) else {
-                return nil
-        }
-        
-        return "\(long),\(lat)"
-    }
     
     
     // MARK: Getting the Direction of Approach

--- a/MapboxDirectionsTests/RouteOptionsTests.swift
+++ b/MapboxDirectionsTests/RouteOptionsTests.swift
@@ -122,7 +122,7 @@ class RouteOptionsTests: XCTestCase {
         let subject = DirectionsOptions(waypoints: wpts)
         
         let answer = subject.queries
-        let correct = ["53.03219, 9.9455", "54.03219, 10.9455"]
+        let correct = ["53.03219,9.9455", "54.03219,10.9455"]
         XCTAssert(answer == correct, "Coordinates should be truncated.")
         
     }

--- a/MapboxDirectionsTests/RouteOptionsTests.swift
+++ b/MapboxDirectionsTests/RouteOptionsTests.swift
@@ -112,6 +112,20 @@ class RouteOptionsTests: XCTestCase {
         let hasApproaches = !params.filter { $0.name == "approaches" }.isEmpty
         XCTAssertFalse(hasApproaches, "approaches query param should be omitted unless any waypoint is restricted to curb")
     }
+    
+    func testDecimalPrecision() {
+        let start = CLLocationCoordinate2D(latitude: 9.945497000000003, longitude: 53.03218800000006)
+        let end = CLLocationCoordinate2D(latitude: 10.945497000000003, longitude: 54.03218800000006)
+
+        let wpts = [start, end].map { Waypoint(coordinate: $0) }
+
+        let subject = DirectionsOptions(waypoints: wpts)
+        
+        let answer = subject.queries
+        let correct = ["53.03219, 9.9455", "54.03219, 10.9455"]
+        XCTAssert(answer == correct, "Coordinates should be truncated.")
+        
+    }
 }
 
 private extension RouteOptions {

--- a/MapboxDirectionsTests/RouteOptionsTests.swift
+++ b/MapboxDirectionsTests/RouteOptionsTests.swift
@@ -122,7 +122,7 @@ class RouteOptionsTests: XCTestCase {
         let subject = DirectionsOptions(waypoints: wpts)
         
         let answer = subject.queries
-        let correct = ["53.03219,9.9455", "54.03219,10.9455"]
+        let correct = ["53.032188,9.945497", "54.032188,10.945497"]
         XCTAssert(answer == correct, "Coordinates should be truncated.")
         
     }


### PR DESCRIPTION
Fixes #309. Adds number formatter that truncates coordinates to relevant number of decimal places, depending on `shapeFormat` setting.