### PR TITLE
Fix argument names in documentation

### DIFF
--- a/MapboxDirections/MBLaneIndicationComponent.swift
+++ b/MapboxDirections/MBLaneIndicationComponent.swift
@@ -24,7 +24,7 @@ open class LaneIndicationComponent: NSObject, ComponentRepresentable {
      Initializes a new visual instruction component object that displays the given information.
      
      - parameter indications: The directions to go from a lane component.
-     - parameter isLaneActive: The flag to indicate that the upcoming maneuver can be completed with a lane component.
+     - parameter isUsable: The flag to indicate that the upcoming maneuver can be completed with a lane component.
      */
     @objc public init(indications: LaneIndication, isUsable: Bool) {
         self.indications = indications

--- a/MapboxDirections/MBRoute.swift
+++ b/MapboxDirections/MBRoute.swift
@@ -20,7 +20,7 @@ open class Route: DirectionsResult {
      
      - parameter json: A JSON dictionary representation of the route as returned by the Mapbox Directions API.
      - parameter waypoints: An array of waypoints that the route visits in chronological order.
-     - parameter routeOptions: The `RouteOptions` used to create the request.
+     - parameter options: The options used when requesting the route.
      */
     @objc(initWithJSON:waypoints:routeOptions:)
     public init(json: [String: Any], waypoints: [Waypoint], options: RouteOptions) {

--- a/MapboxDirections/MBRouteLeg.swift
+++ b/MapboxDirections/MBRouteLeg.swift
@@ -55,7 +55,7 @@ open class RouteLeg: NSObject, NSSecureCoding {
      - parameter json: A JSON dictionary representation of a route leg object as returnd by the Mapbox Directions API.
      - parameter source: The waypoint at the beginning of the leg.
      - parameter destination: The waypoint at the end of the leg.
-     - parameter profileIdentifier: The profile identifier used to request the routes.
+     - parameter options: The options used when requesting the route.
      */
     @objc(initWithJSON:source:destination:options:)
     public convenience init(json: [String: Any], source: Waypoint, destination: Waypoint, options: RouteOptions) {


### PR DESCRIPTION
Corrected some incorrect argument names in documentation comments that produced the following warnings in the navigation SDK:

```
/path/to/mapbox-navigation-ios/Carthage/Build/iOS/MapboxDirections.framework/Headers/MapboxDirections-Swift.h:480:12: Parameter 'isLaneActive' not found in the function declaration
/path/to/mapbox-navigation-ios/Example/MBViewController.m:4:9: While building module 'MapboxCoreNavigation' imported from /path/to/mapbox-navigation-ios/Example/MBViewController.m:4:
/Users/mxn/Library/Developer/Xcode/DerivedData/MapboxNavigation-alytgpeiocddhmempehvwkpsbezh/Build/Products/Debug-iphonesimulator/MapboxCoreNavigation.framework/Headers/MapboxCoreNavigation-Swift.h:169:9: While building module 'MapboxDirections' imported from /Users/mxn/Library/Developer/Xcode/DerivedData/MapboxNavigation-alytgpeiocddhmempehvwkpsbezh/Build/Products/Debug-iphonesimulator/MapboxCoreNavigation.framework/Headers/MapboxCoreNavigation-Swift.h:169:
/<module-includes>:2:9: In file included from <module-includes>:2:
/path/to/mapbox-navigation-ios/Carthage/Build/iOS/MapboxDirections.framework/Headers/MapboxDirections-Swift.h:480:12: Did you mean 'isUsable'?
/path/to/mapbox-navigation-ios/Carthage/Build/iOS/MapboxDirections.framework/Headers/MapboxDirections-Swift.h:657:12: Parameter 'routeOptions' not found in the function declaration
/path/to/mapbox-navigation-ios/Example/MBViewController.m:4:9: While building module 'MapboxCoreNavigation' imported from /path/to/mapbox-navigation-ios/Example/MBViewController.m:4:
/Users/mxn/Library/Developer/Xcode/DerivedData/MapboxNavigation-alytgpeiocddhmempehvwkpsbezh/Build/Products/Debug-iphonesimulator/MapboxCoreNavigation.framework/Headers/MapboxCoreNavigation-Swift.h:169:9: While building module 'MapboxDirections' imported from /Users/mxn/Library/Developer/Xcode/DerivedData/MapboxNavigation-alytgpeiocddhmempehvwkpsbezh/Build/Products/Debug-iphonesimulator/MapboxCoreNavigation.framework/Headers/MapboxCoreNavigation-Swift.h:169:
/<module-includes>:2:9: In file included from <module-includes>:2:
/path/to/mapbox-navigation-ios/Carthage/Build/iOS/MapboxDirections.framework/Headers/MapboxDirections-Swift.h:657:12: Did you mean 'options'?
/path/to/mapbox-navigation-ios/Carthage/Build/iOS/MapboxDirections.framework/Headers/MapboxDirections-Swift.h:677:12: Parameter 'profileIdentifier' not found in the function declaration
/path/to/mapbox-navigation-ios/Example/MBViewController.m:4:9: While building module 'MapboxCoreNavigation' imported from /path/to/mapbox-navigation-ios/Example/MBViewController.m:4:
/Users/mxn/Library/Developer/Xcode/DerivedData/MapboxNavigation-alytgpeiocddhmempehvwkpsbezh/Build/Products/Debug-iphonesimulator/MapboxCoreNavigation.framework/Headers/MapboxCoreNavigation-Swift.h:169:9: While building module 'MapboxDirections' imported from /Users/mxn/Library/Developer/Xcode/DerivedData/MapboxNavigation-alytgpeiocddhmempehvwkpsbezh/Build/Products/Debug-iphonesimulator/MapboxCoreNavigation.framework/Headers/MapboxCoreNavigation-Swift.h:169:
/<module-includes>:2:9: In file included from <module-includes>:2:
/path/to/mapbox-navigation-ios/Carthage/Build/iOS/MapboxDirections.framework/Headers/MapboxDirections-Swift.h:677:12: Did you mean 'options'?
```

/cc @vincethecoder @frederoni