### PR TITLE
Making apiEndpoint and accessToken publicly readable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changes to the Mapbox Directions SDK for iOS
 
+## master
+
+* `Directions.apiEndpoint` and `Directions.accessToken` are now publicly readable, making it easier to share this information with other classes which might need it.
+
 ## v0.25.0
 
 * Added `Directions.fetchAvailableOfflineVersions(completionHandler:)` for listing available offline versions. ([#303](https://github.com/mapbox/MapboxDirections.swift/pull/303))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## master
 
-* `Directions.apiEndpoint` and `Directions.accessToken` are now publicly readable, making it easier to share this information with other classes which might need it.
+* Added the `Directions.apiEndpoint` and `Directions.accessToken` properties that reflect the values passed into the `Directions` class’s initializers. ([#313](https://github.com/mapbox/MapboxDirections.swift/pull/313))
 
 ## v0.25.0
 

--- a/MapboxDirections/MBDirections.swift
+++ b/MapboxDirections/MBDirections.swift
@@ -90,11 +90,15 @@ open class Directions: NSObject {
     @objc(sharedDirections)
     public static let shared = Directions(accessToken: nil)
     
-    /// The API endpoint to request the directions from.
-    internal var apiEndpoint: URL
+    /**
+     The API endpoint to use when requesting directions.
+     */
+    @objc public private(set) var apiEndpoint: URL
     
-    /// The Mapbox access token to associate the request with.
-    internal let accessToken: String
+    /**
+     The Mapbox access token to associate with the request.
+     */
+    @objc public let accessToken: String
     
     /**
      Initializes a newly created directions object with an optional access token and host.


### PR DESCRIPTION
This makes it easier to share this information with other objects which might need it.

Fixes https://github.com/mapbox/MapboxDirections.swift/issues/308