### PR TITLE
Refine Obj-C bridging for CoordinateBounds

### DIFF
--- a/MapboxDirections/MBCoordinateBounds.swift
+++ b/MapboxDirections/MBCoordinateBounds.swift
@@ -23,7 +23,7 @@ public class CoordinateBounds: NSObject, Codable {
      Initializes a `BoundingBox` from an array of `CLLocationCoordinate2D`’s.
      */
     @objc
-    convenience public init(_ coordinates: [CLLocationCoordinate2D]) {
+    convenience public init(coordinates: [CLLocationCoordinate2D]) {
         assert(coordinates.count >= 2, "coordinates must consist of at least two coordinates")
         
         var maximumLatitude: CLLocationDegrees = -90

--- a/OfflineDirectionsTests.swift
+++ b/OfflineDirectionsTests.swift
@@ -39,9 +39,9 @@ class OfflineDirectionsTests: XCTestCase {
     func testDownloadTiles() {
         
         let directions = Directions(accessToken: token, host: host)
-        
-        let coordinateBounds = CoordinateBounds([CLLocationCoordinate2D(latitude: 37.7890, longitude: -122.4337),
-                                                 CLLocationCoordinate2D(latitude: 37.7881, longitude: -122.4318)])
+
+        let bounds = CoordinateBounds(coordinates: [CLLocationCoordinate2D(latitude: 37.7890, longitude: -122.4337),
+                                                    CLLocationCoordinate2D(latitude: 37.7881, longitude: -122.4318)])
         
         let version = "2018-10-16"
         let downloadExpectation = self.expectation(description: "Download tile expectation")
@@ -62,7 +62,7 @@ class OfflineDirectionsTests: XCTestCase {
             return OHHTTPStubsResponse(fileAtPath: path!, statusCode: 200, headers: headers)
         }
         
-        _ = directions.downloadTiles(in: coordinateBounds, version: version, completionHandler: { (url, response, error) in
+        _ = directions.downloadTiles(in: bounds, version: version, completionHandler: { (url, response, error) in
             XCTAssertEqual(response!.suggestedFilename, "2018-10-16.tar")
             XCTAssertNotNil(url, "url should point to the temporary local file")
             XCTAssertNil(error)


### PR DESCRIPTION
This is a breaking change so we have to bump the minor version number for next release.

cc @1ec5 @JThramer 