### PR TITLE
Fix coding of routes, intersections, waypoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changes to the Mapbox Directions SDK for iOS
 
+## master
+
+* `Waypoint`s and `Tracepoint`s can now be compared for object equality. ([#331](https://github.com/mapbox/MapboxDirections.swift/pull/331))
+* Fixed an issue where the `DirectionsResult.accessToken` and `DirectionsResult.apiEndpoint` properties failed to roundtrip through `NSCoder`. ([#331](https://github.com/mapbox/MapboxDirections.swift/pull/331))
+* `Route` now supports secure coding via the `NSSecureCoding` protocol. ([#331](https://github.com/mapbox/MapboxDirections.swift/pull/331))
+* Fixed an issue where `Intersection` failed to decode when an outlet road has no road classes (i.e., a normal road that isn’t a bridge, tunnel, toll road, or motorway). ([#331](https://github.com/mapbox/MapboxDirections.swift/pull/331))
+
 ## v0.26.0
 
 * Renamed `CoordinateBounds(_:)` to `CoordinateBounds(coordinates:)`. ([#325](https://github.com/mapbox/MapboxDirections.swift/pull/325))

--- a/MapboxDirections/MBDirectionsResult.swift
+++ b/MapboxDirections/MBDirectionsResult.swift
@@ -21,6 +21,9 @@ open class DirectionsResult: NSObject, NSSecureCoding {
     }
         
     @objc public required init?(coder decoder: NSCoder) {
+        accessToken = decoder.decodeObject(of: NSString.self, forKey: "accessToken") as String?
+        apiEndpoint = decoder.decodeObject(of: NSURL.self, forKey: "apiEndpoint") as URL?
+        
         let coordinateDictionaries = decoder.decodeObject(of: [NSArray.self, NSDictionary.self, NSString.self, NSNumber.self], forKey: "coordinates") as? [[String: CLLocationDegrees]]
         coordinates = coordinateDictionaries?.compactMap({ (coordinateDictionary) -> CLLocationCoordinate2D? in
             if let latitude = coordinateDictionary["latitude"],
@@ -50,6 +53,9 @@ open class DirectionsResult: NSObject, NSSecureCoding {
     }
     
     @objc public func encode(with coder: NSCoder) {
+        coder.encode(accessToken, forKey: "accessToken")
+        coder.encode(apiEndpoint, forKey: "apiEndpoint")
+        
         let coordinateDictionaries = coordinates?.map { [
             "latitude": $0.latitude,
             "longitude": $0.longitude,

--- a/MapboxDirections/MBIntersection.swift
+++ b/MapboxDirections/MBIntersection.swift
@@ -116,11 +116,11 @@ public class Intersection: NSObject, NSSecureCoding {
         approachLanes = decoder.decodeObject(of: [NSArray.self, Lane.self], forKey: "approachLanes") as? [Lane]
         usableApproachLanes = decoder.decodeObject(of: NSIndexSet.self, forKey: "usableApproachLanes") as IndexSet?
         
-        guard let descriptions = decoder.decodeObject(of: NSString.self, forKey: "outletRoadClasses") as String?,
-            let outletRoadClasses = RoadClasses(descriptions: descriptions.components(separatedBy: ",")) else {
-                return nil
+        if let descriptions = decoder.decodeObject(of: NSString.self, forKey: "outletRoadClasses") as String? {
+            outletRoadClasses = RoadClasses(descriptions: descriptions.components(separatedBy: ","))
+        } else {
+            outletRoadClasses = nil
         }
-        self.outletRoadClasses = outletRoadClasses
     }
     
     public static var supportsSecureCoding = true

--- a/MapboxDirections/MBRoute.swift
+++ b/MapboxDirections/MBRoute.swift
@@ -50,6 +50,10 @@ open class Route: DirectionsResult {
     @objc public required init?(coder decoder: NSCoder) {
         super.init(coder: decoder)
     }
+    
+    override public class var supportsSecureCoding: Bool {
+        return true
+    }
 }
 
 // MARK: Support for Directions API v4

--- a/MapboxDirections/MBWaypoint.swift
+++ b/MapboxDirections/MBWaypoint.swift
@@ -96,7 +96,28 @@ open class Waypoint: NSObject, NSCopying, NSSecureCoding {
         copy.allowsArrivingOnOppositeSide = allowsArrivingOnOppositeSide
         return copy
     }
-
+    
+    // MARK: Objective-C equality
+    open override func isEqual(_ object: Any?) -> Bool {
+        guard let opts = object as? Waypoint else { return false }
+        return isEqual(to: opts)
+    }
+    
+    @objc(isEqualToWaypoint:)
+    open func isEqual(to other: Waypoint?) -> Bool {
+        guard let other = other else { return false }
+        return type(of: self) == type(of: other) &&
+            coordinate.latitude == other.coordinate.latitude &&
+            coordinate.longitude == other.coordinate.longitude &&
+            coordinateAccuracy == other.coordinateAccuracy &&
+            targetCoordinate.latitude == other.targetCoordinate.latitude &&
+            targetCoordinate.longitude == other.targetCoordinate.longitude &&
+            heading == other.heading &&
+            headingAccuracy == other.headingAccuracy &&
+            name == other.name &&
+            allowsArrivingOnOppositeSide == other.allowsArrivingOnOppositeSide
+    }
+    
     // MARK: Getting the Waypoint’s Location
 
     /**

--- a/MapboxDirections/Match/MBTracepoint.swift
+++ b/MapboxDirections/Match/MBTracepoint.swift
@@ -27,4 +27,17 @@ public class Tracepoint: Waypoint {
     override public class var supportsSecureCoding: Bool {
         return true
     }
+    
+    // MARK: Objective-C equality
+    open override func isEqual(_ object: Any?) -> Bool {
+        guard let opts = object as? Tracepoint else { return false }
+        return isEqual(to: opts)
+    }
+    
+    @objc(isEqualToTracepoint:)
+    open func isEqual(to other: Tracepoint?) -> Bool {
+        guard let other = other else { return false }
+        return super.isEqual(to: other) && type(of: self) == type(of: other) &&
+            alternateCount == other.alternateCount
+    }
 }


### PR DESCRIPTION
This PR fixes several intertwined coding-related issues. The first is that Route now supports secure coding via the `NSSecureCoding` protocol. But in testing that quick fix, I pulled a thread that unfurled into the following fixes:

* Fixed an issue where the `DirectionsResult.accessToken` and `DirectionsResult.apiEndpoint` properties failed to roundtrip through NSCoder.
* Fixed an issue where Intersection failed to decode when an outlet road has no road classes (i.e., a normal road that isn’t a bridge, tunnel, toll road, or motorway).
* Implemented object equality checks for Waypoint and Tracepoint.

/cc @frederoni @JThramer @samfader