### PR TITLE
Update URLs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,7 +63,7 @@
 * Added types `.exit` and `.exitCodes` to `MBVisualInstructionType`. (#252)
 * Made an initializer on `MBLane` public. (#253)
 
-This release includes the ability to make a [Mapbox Map Matching request](https://www.mapbox.com/api-documentation/navigation/#map-matching).
+This release includes the ability to make a [Mapbox Map Matching request](https://docs.mapbox.com/api/navigation/#map-matching).
 
 ## v0.19.0
 
@@ -217,7 +217,7 @@ This is a complete rewrite of MapboxDirections.swift that focuses on making the 
 
 * Most types and methods can now be used in Objective-C.
 * Removed the `MB` class prefix from Swift but kept it for Objective-C. If any type conflicts with a type in your application’s module, prefix it with `MapboxDirections.`.
-* Added a shared (singleton) `Directions` object. Use the shared object if you’ve set your Mapbox access token in the `MGLMapboxAccessToken` key of your application’s Info.plist file. (You may have already done so if you’ve installed the [Mapbox iOS SDK](https://www.mapbox.com/ios-sdk/) or [Mapbox OS X SDK](https://github.com/mapbox/mapbox-gl-native/tree/master/platform/osx).) Otherwise, create a `Directions` object with the access token explicitly.
+* Added a shared (singleton) `Directions` object. Use the shared object if you’ve set your Mapbox access token in the `MGLMapboxAccessToken` key of your application’s Info.plist file. (You may have already done so if you’ve installed the [Mapbox iOS SDK](https://docs.mapbox.com/ios/maps/) or [Mapbox OS X SDK](https://mapbox.github.io/mapbox-gl-native/macos/).) Otherwise, create a `Directions` object with the access token explicitly.
 * Simplified the networking part of the library:
   * Removed the dependency on RequestKit. If you’re upgrading to this version using CocoaPods, you can remove the `NBNRequestKit` dependency override.
   * `Directions` no longer needs to be strongly held in order for the request to finish. Instead, the request is made against the shared URL session; to use a custom URL session, make the request yourself using the URL returned by the `URLForCalculatingDirections(options:)` property.
@@ -239,7 +239,7 @@ Other changes since v0.5.0:
 * Added a way to specify the heading accuracy of any waypoint. ([#47](https://github.com/mapbox/MapboxDirections.swift/pull/47))
 * By default, returned routes may U-turn at intermediate waypoints. ([#47](https://github.com/mapbox/MapboxDirections.swift/pull/47))
 * Various error conditions returned by the API, such as the rate limiting error, cause the localized failure reason and recovery suggestion to be set in the NSError object that is passed into the completion handler. ([#47](https://github.com/mapbox/MapboxDirections.swift/pull/47))
-* Requests sent through this library now use a more specific user agent string, so you can more easily identify this library on [your Statistics page in Mapbox Studio](https://www.mapbox.com/studio/stats/). ([#50](https://github.com/mapbox/MapboxDirections.swift/pull/50))
+* Requests sent through this library now use a more specific user agent string, so you can more easily identify this library on [your Statistics page in Mapbox Studio](https://account.mapbox.com/statistics/). ([#50](https://github.com/mapbox/MapboxDirections.swift/pull/50))
 
 ## v0.5.0
 

--- a/Directions Example/ViewController.m
+++ b/Directions Example/ViewController.m
@@ -4,7 +4,7 @@
 #import "ViewController.h"
 
 // A Mapbox access token is required to use the Directions API.
-// https://www.mapbox.com/help/create-api-access-token/
+// https://docs.mapbox.com/help/how-mapbox-works/access-tokens/#creating-and-managing-access-tokens
 NSString * const MapboxAccessToken = @"<# your Mapbox access token #>";
 
 @interface ViewController ()

--- a/Directions Example/ViewController.swift
+++ b/Directions Example/ViewController.swift
@@ -4,7 +4,7 @@ import MapboxDirections
 import Mapbox
 
 // A Mapbox access token is required to use the Directions API.
-// https://www.mapbox.com/help/create-api-access-token/
+// https://docs.mapbox.com/help/how-mapbox-works/access-tokens/#creating-and-managing-access-tokens
 let MapboxAccessToken = "<# your Mapbox access token #>"
 
 class ViewController: UIViewController, MBDrawingViewDelegate {

--- a/MapboxDirections.swift.podspec
+++ b/MapboxDirections.swift.podspec
@@ -10,8 +10,8 @@ Pod::Spec.new do |s|
   MapboxDirections.swift makes it easy to connect your iOS, macOS, tvOS, or watchOS application to the Mapbox Directions API. Quickly get driving, cycling, or walking directions, whether the trip is nonstop or it has multiple stopping points, all using a simple interface reminiscent of MapKit’s `MKDirections` API. The Mapbox Directions API is powered by the OSRM routing engine and open data from the OpenStreetMap project.
                    DESC
 
-  s.homepage     = "https://www.mapbox.com/directions/"
-  s.documentation_url = "https://www.mapbox.com/ios-sdk/api/directions/"
+  s.homepage     = "https://www.mapbox.com/navigation/"
+  s.documentation_url = "https://docs.mapbox.com/ios/api/directions/"
 
   # ―――  Spec License  ――――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
 

--- a/MapboxDirections/MBDirections.swift
+++ b/MapboxDirections/MBDirections.swift
@@ -53,7 +53,7 @@ let userAgent: String = {
 }()
 
 /**
- A `Directions` object provides you with optimal directions between different locations, or waypoints. The directions object passes your request to the [Mapbox Directions API](https://www.mapbox.com/api-documentation/navigation/#directions) and returns the requested information to a closure (block) that you provide. A directions object can handle multiple simultaneous requests. A `RouteOptions` object specifies criteria for the results, such as intermediate waypoints, a mode of transportation, or the level of detail to be returned.
+ A `Directions` object provides you with optimal directions between different locations, or waypoints. The directions object passes your request to the [Mapbox Directions API](https://docs.mapbox.com/api/navigation/#directions) and returns the requested information to a closure (block) that you provide. A directions object can handle multiple simultaneous requests. A `RouteOptions` object specifies criteria for the results, such as intermediate waypoints, a mode of transportation, or the level of detail to be returned.
 
  Each result produced by the directions object is stored in a `Route` object. Depending on the `RouteOptions` object you provide, each route may include detailed information suitable for turn-by-turn directions, or it may include only high-level information such as the distance, estimated travel time, and name of each leg of the trip. The waypoints that form the request may be conflated with nearby locations, as appropriate; the resulting waypoints are provided to the closure.
  */
@@ -85,7 +85,7 @@ open class Directions: NSObject {
     /**
      The shared directions object.
 
-     To use this object, a Mapbox [access token](https://www.mapbox.com/help/define-access-token/) should be specified in the `MGLMapboxAccessToken` key in the main application bundle’s Info.plist.
+     To use this object, a Mapbox [access token](https://docs.mapbox.com/help/glossary/access-token/) should be specified in the `MGLMapboxAccessToken` key in the main application bundle’s Info.plist.
      */
     @objc(sharedDirections)
     public static let shared = Directions(accessToken: nil)
@@ -103,12 +103,12 @@ open class Directions: NSObject {
     /**
      Initializes a newly created directions object with an optional access token and host.
 
-     - parameter accessToken: A Mapbox [access token](https://www.mapbox.com/help/define-access-token/). If an access token is not specified when initializing the directions object, it should be specified in the `MGLMapboxAccessToken` key in the main application bundle’s Info.plist.
-     - parameter host: An optional hostname to the server API. The [Mapbox Directions API](https://www.mapbox.com/api-documentation/navigation/#directions) endpoint is used by default.
+     - parameter accessToken: A Mapbox [access token](https://docs.mapbox.com/help/glossary/access-token/). If an access token is not specified when initializing the directions object, it should be specified in the `MGLMapboxAccessToken` key in the main application bundle’s Info.plist.
+     - parameter host: An optional hostname to the server API. The [Mapbox Directions API](https://docs.mapbox.com/api/navigation/#directions) endpoint is used by default.
      */
     @objc public init(accessToken: String?, host: String?) {
         let accessToken = accessToken ?? defaultAccessToken
-        assert(accessToken != nil && !accessToken!.isEmpty, "A Mapbox access token is required. Go to <https://www.mapbox.com/studio/account/tokens/>. In Info.plist, set the MGLMapboxAccessToken key to your access token, or use the Directions(accessToken:host:) initializer.")
+        assert(accessToken != nil && !accessToken!.isEmpty, "A Mapbox access token is required. Go to <https://account.mapbox.com/access-tokens/>. In Info.plist, set the MGLMapboxAccessToken key to your access token, or use the Directions(accessToken:host:) initializer.")
 
         self.accessToken = accessToken!
 
@@ -126,9 +126,9 @@ open class Directions: NSObject {
     /**
      Initializes a newly created directions object with an optional access token.
 
-     The directions object sends requests to the [Mapbox Directions API](https://www.mapbox.com/api-documentation/navigation/#directions) endpoint.
+     The directions object sends requests to the [Mapbox Directions API](https://docs.mapbox.com/api/navigation/#directions) endpoint.
 
-     - parameter accessToken: A Mapbox [access token](https://www.mapbox.com/help/define-access-token/). If an access token is not specified when initializing the directions object, it should be specified in the `MGLMapboxAccessToken` key in the main application bundle’s Info.plist.
+     - parameter accessToken: A Mapbox [access token](https://docs.mapbox.com/help/glossary/access-token/). If an access token is not specified when initializing the directions object, it should be specified in the `MGLMapboxAccessToken` key in the main application bundle’s Info.plist.
      */
     @objc public convenience init(accessToken: String?) {
         self.init(accessToken: accessToken, host: nil)
@@ -141,7 +141,7 @@ open class Directions: NSObject {
 
      This method retrieves the routes asynchronously over a network connection. If a connection error or server error occurs, details about the error are passed into the given completion handler in lieu of the routes.
 
-     Routes may be displayed atop a [Mapbox map](https://www.mapbox.com/maps/). They may be cached but may not be stored permanently. To use the results in other contexts or store them permanently, [upgrade to a Mapbox enterprise plan](https://www.mapbox.com/directions/#pricing).
+     Routes may be displayed atop a [Mapbox map](https://www.mapbox.com/maps/). They may be cached but may not be stored permanently. To use the results in other contexts or store them permanently, [upgrade to a Mapbox enterprise plan](https://www.mapbox.com/navigation/#pricing).
 
      - parameter options: A `RouteOptions` object specifying the requirements for the resulting routes.
      - parameter completionHandler: The closure (block) to call with the resulting routes. This closure is executed on the application’s main thread.

--- a/MapboxDirections/MBDirectionsOptions.swift
+++ b/MapboxDirections/MBDirectionsOptions.swift
@@ -219,7 +219,7 @@ open class DirectionsOptions: NSObject, NSSecureCoding, NSCopying {
 
      Do not call `DirectionsOptions(waypoints:profileIdentifier:)` directly; instead call the corresponding initializer of `RouteOptions` or `MatchOptions`.
 
-     - parameter waypoints: An array of `Waypoint` objects representing locations that the route should visit in chronological order. The array should contain at least two waypoints (the source and destination) and at most 25 waypoints. (Some profiles, such as `MBDirectionsProfileIdentifierAutomobileAvoidingTraffic`, [may have lower limits](https://www.mapbox.com/api-documentation/navigation/#directions).)
+     - parameter waypoints: An array of `Waypoint` objects representing locations that the route should visit in chronological order. The array should contain at least two waypoints (the source and destination) and at most 25 waypoints. (Some profiles, such as `MBDirectionsProfileIdentifierAutomobileAvoidingTraffic`, [may have lower limits](https://docs.mapbox.com/api/navigation/#directions).)
      - parameter profileIdentifier: A string specifying the primary mode of transportation for the routes. This parameter, if set, should be set to `MBDirectionsProfileIdentifierAutomobile`, `MBDirectionsProfileIdentifierAutomobileAvoidingTraffic`, `MBDirectionsProfileIdentifierCycling`, or `MBDirectionsProfileIdentifierWalking`. `MBDirectionsProfileIdentifierAutomobile` is used by default.
      */
     @objc required public init(waypoints: [Waypoint], profileIdentifier: MBDirectionsProfileIdentifier? = nil) {
@@ -393,7 +393,7 @@ open class DirectionsOptions: NSObject, NSSecureCoding, NSCopying {
 
      If you use MapboxDirections.swift with the Mapbox Directions API or Map Matching API, this property affects the sentence contained within the `RouteStep.instructions` property, but it does not affect any road names contained in that property or other properties such as `RouteStep.name`.
 
-     The Directions API can provide instructions in [a number of languages](https://www.mapbox.com/api-documentation/navigation/#instructions-languages). Set this property to `Bundle.main.preferredLocalizations.first` or `Locale.autoupdatingCurrent` to match the application’s language or the system language, respectively.
+     The Directions API can provide instructions in [a number of languages](https://docs.mapbox.com/api/navigation/#instructions-languages). Set this property to `Bundle.main.preferredLocalizations.first` or `Locale.autoupdatingCurrent` to match the application’s language or the system language, respectively.
 
      By default, this property is set to the current system locale.
      */

--- a/MapboxDirections/MBDirectionsResult.swift
+++ b/MapboxDirections/MBDirectionsResult.swift
@@ -75,7 +75,7 @@ open class DirectionsResult: NSObject, NSSecureCoding {
      
      This array may be `nil` or simplified depending on the `routeShapeResolution` property of the original `RouteOptions` object.
      
-     Using the [Mapbox Maps SDK for iOS](https://www.mapbox.com/ios-sdk/) or [Mapbox Maps SDK for macOS](https://github.com/mapbox/mapbox-gl-native/tree/master/platform/macos/), you can create an `MGLPolyline` object using these coordinates to display an overview of the route on an `MGLMapView`.
+     Using the [Mapbox Maps SDK for iOS](https://docs.mapbox.com/ios/maps/) or [Mapbox Maps SDK for macOS](https://mapbox.github.io/mapbox-gl-native/macos/), you can create an `MGLPolyline` object using these coordinates to display an overview of the route on an `MGLMapView`.
      */
     @objc public let coordinates: [CLLocationCoordinate2D]?
     
@@ -95,7 +95,7 @@ open class DirectionsResult: NSObject, NSSecureCoding {
      
      The array may be empty or simplified depending on the `routeShapeResolution` property of the original `RouteOptions` object.
      
-     Using the [Mapbox Maps SDK for iOS](https://www.mapbox.com/ios-sdk/) or [Mapbox Maps SDK for macOS](https://github.com/mapbox/mapbox-gl-native/tree/master/platform/macos/), you can create an `MGLPolyline` object using these coordinates to display an overview of the route on an `MGLMapView`.
+     Using the [Mapbox Maps SDK for iOS](https://docs.mapbox.com/ios/maps/) or [Mapbox Maps SDK for macOS](https://mapbox.github.io/mapbox-gl-native/macos/), you can create an `MGLPolyline` object using these coordinates to display an overview of the route on an `MGLMapView`.
      
      - parameter coordinates: A pointer to a C array of `CLLocationCoordinate2D` instances. On output, this array contains all the vertices of the overlay.
      
@@ -148,7 +148,7 @@ open class DirectionsResult: NSObject, NSSecureCoding {
     @objc public let directionsOptions: DirectionsOptions
     
     /**
-     The [access token](https://www.mapbox.com/help/define-access-token/) used to make the directions request.
+     The [access token](https://docs.mapbox.com/help/glossary/access-token/) used to make the directions request.
      
      This property is set automatically if a request is made via `Directions.calculate(_:completionHandler:)`.
      */

--- a/MapboxDirections/MBRouteLeg.swift
+++ b/MapboxDirections/MBRouteLeg.swift
@@ -165,7 +165,7 @@ open class RouteLeg: NSObject, NSSecureCoding {
     /**
      An array containing the traffic congestion level along each road segment in the route leg geometry.
 
-     Traffic data is available in [a number of countries and territories worldwide](https://www.mapbox.com/help/how-directions-work/#traffic-data).
+     Traffic data is available in [a number of countries and territories worldwide](https://docs.mapbox.com/help/how-mapbox-works/directions/#traffic-data).
 
      You can color-code a route line according to the congestion level along each segment of the route.
 

--- a/MapboxDirections/MBRouteOptions.h
+++ b/MapboxDirections/MBRouteOptions.h
@@ -19,7 +19,7 @@ extern MBDirectionsProfileIdentifier const MBDirectionsProfileIdentifierAutomobi
  
  This profile avoids traffic congestion based on current traffic data. A driving route may use a ferry where necessary.
  
- Traffic data is available in [a number of countries and territories worldwide](https://www.mapbox.com/api-documentation/pages/traffic-countries.html). Where traffic data is unavailable, this profile prefers high-speed roads like highways, similar to `MBDirectionsProfileIdentifierAutomobile`.
+ Traffic data is available in [a number of countries and territories worldwide](https://docs.mapbox.com/help/how-mapbox-works/directions/#traffic-data). Where traffic data is unavailable, this profile prefers high-speed roads like highways, similar to `MBDirectionsProfileIdentifierAutomobile`.
  */
 extern MBDirectionsProfileIdentifier const MBDirectionsProfileIdentifierAutomobileAvoidingTraffic;
 

--- a/MapboxDirections/MBRouteOptions.swift
+++ b/MapboxDirections/MBRouteOptions.swift
@@ -32,7 +32,7 @@ open class RouteOptions: DirectionsOptions {
     /**
      Initializes a route options object for routes between the given waypoints and an optional profile identifier.
 
-     - parameter waypoints: An array of `Waypoint` objects representing locations that the route should visit in chronological order. The array should contain at least two waypoints (the source and destination) and at most 25 waypoints. (Some profiles, such as `MBDirectionsProfileIdentifierAutomobileAvoidingTraffic`, [may have lower limits](https://www.mapbox.com/api-documentation/navigation/#directions).)
+     - parameter waypoints: An array of `Waypoint` objects representing locations that the route should visit in chronological order. The array should contain at least two waypoints (the source and destination) and at most 25 waypoints. (Some profiles, such as `MBDirectionsProfileIdentifierAutomobileAvoidingTraffic`, [may have lower limits](https://docs.mapbox.com/api/navigation/#directions).)
      - parameter profileIdentifier: A string specifying the primary mode of transportation for the routes. This parameter, if set, should be set to `MBDirectionsProfileIdentifierAutomobile`, `MBDirectionsProfileIdentifierAutomobileAvoidingTraffic`, `MBDirectionsProfileIdentifierCycling`, or `MBDirectionsProfileIdentifierWalking`. `MBDirectionsProfileIdentifierAutomobile` is used by default.
      */
     @objc public required init(waypoints: [Waypoint], profileIdentifier: MBDirectionsProfileIdentifier? = nil) {

--- a/MapboxDirections/MBRouteStep.swift
+++ b/MapboxDirections/MBRouteStep.swift
@@ -618,7 +618,7 @@ open class RouteStep: NSObject, NSSecureCoding {
 
      Normally, you do not create instances of this class directly. Instead, you receive route step objects as part of route objects when you request directions using the `Directions.calculateDirections(options:completionHandler:)` method, setting the `includesSteps` option to `true` in the `RouteOptions` object that you pass into that method.
 
-     - parameter json: A JSON object that conforms to the [route step](https://www.mapbox.com/api-documentation/navigation/#route-step-object) format described in the Directions API documentation.
+     - parameter json: A JSON object that conforms to the [route step](https://docs.mapbox.com/api/navigation/#route-step-object) format described in the Directions API documentation.
      */
     @objc(initWithJSON:options:)
     public convenience init(json: [String: Any], options: RouteOptions) {
@@ -757,7 +757,7 @@ open class RouteStep: NSObject, NSSecureCoding {
 
      The value of this property may be `nil`, for example when the maneuver type is `arrive`.
 
-     Using the [Mapbox Maps SDK for iOS](https://www.mapbox.com/ios-sdk/) or [Mapbox Maps SDK for macOS](https://github.com/mapbox/mapbox-gl-native/tree/master/platform/macos/), you can create an `MGLPolyline` object using these coordinates to display a portion of a route on an `MGLMapView`.
+     Using the [Mapbox Maps SDK for iOS](https://docs.mapbox.com/ios/maps/) or [Mapbox Maps SDK for macOS](https://mapbox.github.io/mapbox-gl-native/macos/), you can create an `MGLPolyline` object using these coordinates to display a portion of a route on an `MGLMapView`.
      */
     @objc public let coordinates: [CLLocationCoordinate2D]?
 
@@ -777,7 +777,7 @@ open class RouteStep: NSObject, NSSecureCoding {
 
      The array may be empty, for example when the maneuver type is `arrive`.
 
-     Using the [Mapbox Maps SDK for iOS](https://www.mapbox.com/ios-sdk/) or [Mapbox Maps SDK for macOS](https://github.com/mapbox/mapbox-gl-native/tree/master/platform/macos/), you can create an `MGLPolyline` object using these coordinates to display a portion of a route on an `MGLMapView`.
+     Using the [Mapbox Maps SDK for iOS](https://docs.mapbox.com/ios/maps/) or [Mapbox Maps SDK for macOS](https://mapbox.github.io/mapbox-gl-native/macos/), you can create an `MGLPolyline` object using these coordinates to display a portion of a route on an `MGLMapView`.
 
      - parameter coordinates: A pointer to a C array of `CLLocationCoordinate2D` instances. On output, this array contains all the vertices of the overlay.
      - returns: True if the step has coordinates and `coordinates` has been populated, or false if the step has no coordinates and `coordinates` has not been modified.

--- a/MapboxDirections/MBSpokenInstruction.swift
+++ b/MapboxDirections/MBSpokenInstruction.swift
@@ -36,7 +36,7 @@ open class SpokenInstruction: NSObject, NSSecureCoding {
     /**
      Initializes a new spoken instruction object based on the given JSON dictionary representation.
 
-     - parameter json: A JSON object that conforms to the [voice instruction](https://www.mapbox.com/api-documentation/navigation/#voice-instruction-object) format described in the Directions API documentation.
+     - parameter json: A JSON object that conforms to the [voice instruction](https://docs.mapbox.com/api/navigation/#voice-instruction-object) format described in the Directions API documentation.
      */
     @objc(initWithJSON:)
     public convenience init(json: [String: Any]) {

--- a/MapboxDirections/MBVisualInstruction.swift
+++ b/MapboxDirections/MBVisualInstruction.swift
@@ -51,7 +51,7 @@ open class VisualInstruction: NSObject, NSSecureCoding {
     /**
      Initializes a new visual instruction object based on the given JSON dictionary representation.
 
-     - parameter json: A JSON object that conforms to the [banner instruction](https://www.mapbox.com/api-documentation/navigation/#banner-instruction-object) format described in the Directions API documentation.
+     - parameter json: A JSON object that conforms to the [banner instruction](https://docs.mapbox.com/api/navigation/#banner-instruction-object) format described in the Directions API documentation.
      */
     @objc(initWithJSON:)
     public convenience init(json: [String: Any]) {

--- a/MapboxDirections/MBVisualInstructionBanner.swift
+++ b/MapboxDirections/MBVisualInstructionBanner.swift
@@ -36,7 +36,7 @@ open class VisualInstructionBanner: NSObject, NSSecureCoding {
     /**
      Initializes a new visual instruction banner object based on the given JSON dictionary representation and a driving side.
 
-     - parameter json: A JSON object that conforms to the [primary or secondary banner](https://www.mapbox.com/api-documentation/navigation/#banner-instruction-object) format described in the Directions API documentation.
+     - parameter json: A JSON object that conforms to the [primary or secondary banner](https://docs.mapbox.com/api/navigation/#banner-instruction-object) format described in the Directions API documentation.
      - parameter drivingSide: The side of the road the user should drive on. This value should be consistent with the containing route step.
      */
     @objc(initWithJSON:drivingSide:)

--- a/MapboxDirections/MBVisualInstructionComponent.swift
+++ b/MapboxDirections/MBVisualInstructionComponent.swift
@@ -48,7 +48,7 @@ open class VisualInstructionComponent: NSObject, ComponentRepresentable {
     /**
      Initializes a new visual instruction component object based on the given JSON dictionary representation.
 
-     - parameter json: A JSON object that conforms to the [banner component](https://www.mapbox.com/api-documentation/navigation/#banner-instruction-object) format described in the Directions API documentation.
+     - parameter json: A JSON object that conforms to the [banner component](https://docs.mapbox.com/api/navigation/#banner-instruction-object) format described in the Directions API documentation.
      */
     @objc(initWithJSON:)
     public convenience init(json: [String: Any]) {

--- a/MapboxDirections/MBWaypoint.swift
+++ b/MapboxDirections/MBWaypoint.swift
@@ -132,7 +132,7 @@ open class Waypoint: NSObject, NSCopying, NSSecureCoding {
 
      By default, the value of this property is a negative number.
 
-     This property corresponds to the [`radiuses`](https://www.mapbox.com/api-documentation/navigation/#retrieve-directions) query parameter in the Mapbox Directions API.
+     This property corresponds to the [`radiuses`](https://docs.mapbox.com/api/navigation/#retrieve-directions) query parameter in the Mapbox Directions API.
      */
     @objc open var coordinateAccuracy: CLLocationAccuracy = -1
 
@@ -143,7 +143,7 @@ open class Waypoint: NSObject, NSCopying, NSSecureCoding {
 
      By default, this property is set to `kCLLocationCoordinate2DInvalid`, meaning the waypoint has no target. This property is ignored on the first waypoint of a `RouteOptions` object, on any waypoint of a `MatchOptions` object, or on any waypoint of a `RouteOptions` object if `DirectionsOptions.includesSteps` is set to `false`.
 
-     This property corresponds to the [`waypoint_targets`](https://www.mapbox.com/api-documentation/navigation/#retrieve-directions) query parameter in the Mapbox Directions API.
+     This property corresponds to the [`waypoint_targets`](https://docs.mapbox.com/api/navigation/#retrieve-directions) query parameter in the Mapbox Directions API.
      */
     @objc open var targetCoordinate: CLLocationCoordinate2D = kCLLocationCoordinate2DInvalid
 
@@ -162,7 +162,7 @@ open class Waypoint: NSObject, NSCopying, NSSecureCoding {
 
      By default, the value of this property is a negative number, meaning that a route is considered viable regardless of the direction of approach.
 
-     This property corresponds to the angles in the [`bearings`](https://www.mapbox.com/api-documentation/navigation/#retrieve-directions) query parameter in the Mapbox Directions API.
+     This property corresponds to the angles in the [`bearings`](https://docs.mapbox.com/api/navigation/#retrieve-directions) query parameter in the Mapbox Directions API.
      */
     @objc open var heading: CLLocationDirection = -1
 
@@ -175,7 +175,7 @@ open class Waypoint: NSObject, NSCopying, NSSecureCoding {
 
      By default, the value of this property is a negative number, meaning that a route is considered viable regardless of the direction of approach.
 
-     This property corresponds to the ranges in the [`bearings`](https://www.mapbox.com/api-documentation/navigation/#retrieve-directions) query parameter in the Mapbox Directions API.
+     This property corresponds to the ranges in the [`bearings`](https://docs.mapbox.com/api/navigation/#retrieve-directions) query parameter in the Mapbox Directions API.
      */
     @objc open var headingAccuracy: CLLocationDirection = -1
 
@@ -190,7 +190,7 @@ open class Waypoint: NSObject, NSCopying, NSSecureCoding {
 
      This property does not affect the route, but you can set the name of a waypoint you pass into a `RouteOptions` object to help you distinguish one waypoint from another in the array of waypoints passed into the completion handler of the `Directions.calculate(_:completionHandler:)` method. This property has no effect if `DirectionsOptions.includesSteps` is set to `false`.
 
-     This property corresponds to the [`waypoint_names`](https://www.mapbox.com/api-documentation/navigation/#retrieve-directions) query parameter in the Mapbox Directions API.
+     This property corresponds to the [`waypoint_names`](https://docs.mapbox.com/api/navigation/#retrieve-directions) query parameter in the Mapbox Directions API.
      */
     @objc open var name: String?
 
@@ -199,7 +199,7 @@ open class Waypoint: NSObject, NSCopying, NSSecureCoding {
 
      This property has no effect if `DirectionsOptions.includesSteps` is set to `false`.
 
-     This property corresponds to the [`approaches`](https://www.mapbox.com/api-documentation/navigation/#retrieve-directions) query parameter in the Mapbox Directions API.
+     This property corresponds to the [`approaches`](https://docs.mapbox.com/api/navigation/#retrieve-directions) query parameter in the Mapbox Directions API.
      */
     @objc open var allowsArrivingOnOppositeSide = true
 

--- a/MapboxDirections/Match/MBMatchOptions.swift
+++ b/MapboxDirections/Match/MBMatchOptions.swift
@@ -12,7 +12,7 @@ open class MatchOptions: DirectionsOptions {
     /**
      Initializes a match options object for matching locations against the road network.
 
-     - parameter locations: An array of `CLLocation` objects representing locations to attempt to match against the road network. The array should contain at least two locations (the source and destination) and at most 25 locations. (Some profiles, such as `MBDirectionsProfileIdentifierAutomobileAvoidingTraffic`, [may have lower limits](https://www.mapbox.com/api-documentation/navigation/#directions).)
+     - parameter locations: An array of `CLLocation` objects representing locations to attempt to match against the road network. The array should contain at least two locations (the source and destination) and at most 25 locations. (Some profiles, such as `MBDirectionsProfileIdentifierAutomobileAvoidingTraffic`, [may have lower limits](https://docs.mapbox.com/api/navigation/#directions).)
      - parameter profileIdentifier: A string specifying the primary mode of transportation for the routes. This parameter, if set, should be set to `MBDirectionsProfileIdentifierAutomobile`, `MBDirectionsProfileIdentifierAutomobileAvoidingTraffic`, `MBDirectionsProfileIdentifierCycling`, or `MBDirectionsProfileIdentifierWalking`. `MBDirectionsProfileIdentifierAutomobile` is used by default.
      */
     @objc public convenience init(locations: [CLLocation], profileIdentifier: MBDirectionsProfileIdentifier? = nil) {
@@ -25,7 +25,7 @@ open class MatchOptions: DirectionsOptions {
     /**
      Initializes a match options object for matching geographic coordinates against the road network.
 
-     - parameter coordinates: An array of geographic coordinates representing locations to attempt to match against the road network. The array should contain at least two locations (the source and destination) and at most 25 locations. (Some profiles, such as `MBDirectionsProfileIdentifierAutomobileAvoidingTraffic`, [may have lower limits](https://www.mapbox.com/api-documentation/navigation/#directions).) Each coordinate is converted into a `Waypoint` object.
+     - parameter coordinates: An array of geographic coordinates representing locations to attempt to match against the road network. The array should contain at least two locations (the source and destination) and at most 25 locations. (Some profiles, such as `MBDirectionsProfileIdentifierAutomobileAvoidingTraffic`, [may have lower limits](https://docs.mapbox.com/api/navigation/#directions).) Each coordinate is converted into a `Waypoint` object.
      - parameter profileIdentifier: A string specifying the primary mode of transportation for the routes. This parameter, if set, should be set to `MBDirectionsProfileIdentifierAutomobile`, `MBDirectionsProfileIdentifierAutomobileAvoidingTraffic`, `MBDirectionsProfileIdentifierCycling`, or `MBDirectionsProfileIdentifierWalking`. `MBDirectionsProfileIdentifierAutomobile` is used by default.
      */
     @objc public convenience init(coordinates: [CLLocationCoordinate2D], profileIdentifier: MBDirectionsProfileIdentifier? = nil) {

--- a/README.md
+++ b/README.md
@@ -7,11 +7,11 @@
 [![Carthage compatible](https://img.shields.io/badge/Carthage-compatible-4BC51D.svg?style=flat)](https://github.com/Carthage/Carthage) &nbsp;&nbsp;&nbsp;
 [![CocoaPods](https://img.shields.io/cocoapods/v/MapboxDirections.swift.svg)](http://cocoadocs.org/docsets/MapboxDirections.swift/)
 
-MapboxDirections.swift makes it easy to connect your iOS, macOS, tvOS, or watchOS application to the [Mapbox Directions API](https://www.mapbox.com/directions/) and [Mapbox Map Matching API](https://www.mapbox.com/directions/). Quickly get driving, cycling, or walking directions, whether the trip is nonstop or it has multiple stopping points, all using a simple interface reminiscent of MapKit’s `MKDirections` API. Fit a GPX trace to the [OpenStreetMap](https://www.openstreetmap.org/) road network. The Mapbox Directions and Map Matching APIs are powered by the [OSRM](http://project-osrm.org/) routing engine.
+MapboxDirections.swift makes it easy to connect your iOS, macOS, tvOS, or watchOS application to the [Mapbox Directions](https://docs.mapbox.com/api/navigation/) and [Map Matching](https://docs.mapbox.com/api/navigation/#map-matching) APIs. Quickly get driving, cycling, or walking directions, whether the trip is nonstop or it has multiple stopping points, all using a simple interface reminiscent of MapKit’s `MKDirections` API. Fit a GPX trace to the [OpenStreetMap](https://www.openstreetmap.org/) road network. The Mapbox Directions and Map Matching APIs are powered by the [OSRM](http://project-osrm.org/) routing engine. For more information, see the [Mapbox Navigation](https://www.mapbox.com/navigation/) homepage.
 
 Despite its name, MapboxDirections.swift works in Objective-C and Cocoa-AppleScript code in addition to Swift 4.
 
-MapboxDirections.swift pairs well with [MapboxGeocoder.swift](https://github.com/mapbox/MapboxGeocoder.swift), [MapboxStatic.swift](https://github.com/mapbox/MapboxStatic.swift), the [Mapbox Navigation SDK for iOS](https://github.com/mapbox/mapbox-navigation-ios/), and the [Mapbox Maps SDK for iOS](https://www.mapbox.com/ios-sdk/) or [macOS SDK](https://mapbox.github.io/mapbox-gl-native/macos/).
+MapboxDirections.swift pairs well with [MapboxGeocoder.swift](https://github.com/mapbox/MapboxGeocoder.swift), [MapboxStatic.swift](https://github.com/mapbox/MapboxStatic.swift), the [Mapbox Navigation SDK for iOS](https://github.com/mapbox/mapbox-navigation-ios/), and the [Mapbox Maps SDK for iOS](https://docs.mapbox.com/ios/maps/) or [macOS SDK](https://mapbox.github.io/mapbox-gl-native/macos/).
 
 ## Getting started
 
@@ -31,15 +31,15 @@ Then `import MapboxDirections` or `@import MapboxDirections;`.
 
 v0.12.1 is the last release of MapboxDirections.swift written in Swift 3. All subsequent releases will be based on the `master` branch, which is written in Swift 4. The Swift examples below are written in Swift 4.
 
-This repository contains example applications written in Swift and Objective-C that demonstrate how to use the framework. To run them, you need to use [Carthage](https://github.com/Carthage/Carthage) 0.19 or above to install the dependencies. Detailed documentation is available in the [Mapbox API Documentation](https://www.mapbox.com/api-documentation/navigation/#directions).
+This repository contains example applications written in Swift and Objective-C that demonstrate how to use the framework. To run them, you need to use [Carthage](https://github.com/Carthage/Carthage) 0.19 or above to install the dependencies. Detailed documentation is available in the [Mapbox API Documentation](https://docs.mapbox.com/api/navigation/#directions).
 
 ## Usage
 
-**[API reference](https://www.mapbox.com/ios-sdk/api/directions/)**
+**[API reference](https://docs.mapbox.com/ios/api/directions/)**
 
-You’ll need a [Mapbox access token](https://www.mapbox.com/developers/api/#access-tokens) in order to use the API. If you’re already using the [Mapbox Maps SDK for iOS](https://www.mapbox.com/ios-sdk/) or [macOS SDK](https://mapbox.github.io/mapbox-gl-native/macos/), MapboxDirections.swift automatically recognizes your access token, as long as you’ve placed it in the `MGLMapboxAccessToken` key of your application’s Info.plist file.
+You’ll need a [Mapbox access token](https://docs.mapbox.com/api/#access-tokens-and-token-scopes) in order to use the API. If you’re already using the [Mapbox Maps SDK for iOS](https://docs.mapbox.com/ios/maps/) or [macOS SDK](https://mapbox.github.io/mapbox-gl-native/macos/), MapboxDirections.swift automatically recognizes your access token, as long as you’ve placed it in the `MGLMapboxAccessToken` key of your application’s Info.plist file.
 
-The examples below are each provided in Swift (denoted with `main.swift`), Objective-C (`main.m`), and AppleScript (`AppDelegate.applescript`). For further details, see the [MapboxDirections.swift API reference](https://www.mapbox.com/ios-sdk/api/directions/).
+The examples below are each provided in Swift (denoted with `main.swift`), Objective-C (`main.m`), and AppleScript (`AppDelegate.applescript`). For further details, see the [MapboxDirections.swift API reference](https://docs.mapbox.com/ios/api/directions/).
 
 ### Calculating directions between locations
 
@@ -297,7 +297,7 @@ You can also use the `Directions.calculateRoutes(matching:completionHandler:)` m
 
 ### Drawing the route on a map
 
-With the [Mapbox Maps SDK for iOS](https://www.mapbox.com/ios-sdk/) or [macOS SDK](https://mapbox.github.io/mapbox-gl-native/macos/), you can easily draw the route on a map in Swift or Objective-C:
+With the [Mapbox Maps SDK for iOS](https://docs.mapbox.com/ios/maps/) or [macOS SDK](https://mapbox.github.io/mapbox-gl-native/macos/), you can easily draw the route on a map in Swift or Objective-C:
 
 ```swift
 // main.swift

--- a/docs/jazzy.yml
+++ b/docs/jazzy.yml
@@ -1,8 +1,8 @@
 module: MapboxDirections
 author: Mapbox
-author_url: https://www.mapbox.com/directions/
+author_url: https://www.mapbox.com/navigation/
 github_url: https://github.com/mapbox/MapboxDirections.swift
-dash_url: https://www.mapbox.com/ios-sdk/docsets/MapboxDirections.xml
+dash_url: https://docs.mapbox.com/ios/docsets/MapboxDirections.xml
 copyright: '© 2014–2017 [Mapbox](https://www.mapbox.com/). See [license](https://github.com/mapbox/MapboxDirections.swift/blob/master/LICENSE.md) for more details.'
 
 head: |


### PR DESCRIPTION
I went through every URL in the repository, resolving redirects and in a few cases replacing URLs with more appropriate URLs. (There was still a broken link to the pre-rename Mapbox OS X SDK on GitHub.)

/cc @mapbox/docs