### PR TITLE
Per-waypoint via point behavior

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## master
 
+* Added the `Waypoint.separatesLegs` property, which you can set to `false` to create a route that travels “via” the waypoint but doesn’t stop there. Deprecated the `MatchOptions.waypointIndices` property in favor of `Waypoint.separatesLegs`, which also works with `RouteOptions`. ([#340](https://github.com/mapbox/MapboxDirections.swift/pull/340]))
+* Fixed unset properties in  `Waypoint` objects that are included in a calculated `Route`s or `Match`es. ([#340](https://github.com/mapbox/MapboxDirections.swift/pull/340]))
 * Added `DirectionsResult.fetchStartDate` and `DirectionsResult.requestEndDate` properties. ([#335](https://github.com/mapbox/MapboxDirections.swift/pull/335))
 
 ## v0.26.1

--- a/MapboxDirections/MBDirectionsOptions.swift
+++ b/MapboxDirections/MBDirectionsOptions.swift
@@ -471,6 +471,15 @@ open class DirectionsOptions: NSObject, NSSecureCoding, NSCopying {
 
             params.append(URLQueryItem(name: "annotations", value: attributesStrings))
         }
+        
+        var waypointIndices = IndexSet(waypoints.enumerated().filter { $0.element.separatesLegs }.map { $0.offset })
+        waypointIndices.insert(waypoints.startIndex)
+        waypointIndices.insert(waypoints.endIndex - 1)
+        if waypointIndices.count < waypoints.count {
+            params.append(URLQueryItem(name: "waypoints", value: waypointIndices.map {
+                String(describing: $0)
+            }.joined(separator: ";")))
+        }
 
         if !waypoints.compactMap({ $0.name }).isEmpty {
             let names = waypoints.map { $0.name ?? "" }.joined(separator: ";")

--- a/MapboxDirections/MBRouteOptions.swift
+++ b/MapboxDirections/MBRouteOptions.swift
@@ -165,7 +165,10 @@ open class RouteOptions: DirectionsOptions {
                 let coordinate = CLLocationCoordinate2D(geoJSON: location)
                 let possibleAPIName = api["name"] as? String
                 let apiName = possibleAPIName?.nonEmptyString
-                return Waypoint(coordinate: coordinate, name: local.name ?? apiName)
+                let waypoint = local.copy() as! Waypoint
+                waypoint.coordinate = coordinate
+                waypoint.name = waypoint.name ?? apiName
+                return waypoint
             }
         }
 

--- a/MapboxDirectionsTests/RoutableMatchTests.swift
+++ b/MapboxDirectionsTests/RoutableMatchTests.swift
@@ -31,8 +31,9 @@ class RoutableMatchTest: XCTestCase {
         let matchOptions = MatchOptions(coordinates: locations)
         matchOptions.includesSteps = true
         matchOptions.routeShapeResolution = .full
-        let indices: IndexSet = [0, locations.count - 1]
-        matchOptions.waypointIndices = indices
+        for waypoint in matchOptions.waypoints[1..<(locations.count - 1)] {
+            waypoint.separatesLegs = false
+        }
         
         
         let task = Directions(accessToken: BogusToken).calculateRoutes(matching: matchOptions) { (wpoints, routes, error) in

--- a/MapboxDirectionsTests/WaypointTests.swift
+++ b/MapboxDirectionsTests/WaypointTests.swift
@@ -1,5 +1,5 @@
 import XCTest
-import MapboxDirections
+@testable import MapboxDirections
 
 class WaypointTests: XCTestCase {
     func testCopying() {
@@ -21,6 +21,7 @@ class WaypointTests: XCTestCase {
         XCTAssertEqual(copy.heading, originalWaypoint.heading)
         XCTAssertEqual(copy.headingAccuracy, originalWaypoint.headingAccuracy)
         XCTAssertEqual(copy.allowsArrivingOnOppositeSide, originalWaypoint.allowsArrivingOnOppositeSide)
+        XCTAssertEqual(copy.separatesLegs, originalWaypoint.separatesLegs)
     }
     
     func testCoding() {
@@ -53,5 +54,29 @@ class WaypointTests: XCTestCase {
         XCTAssertEqual(decodedWaypoint.heading, originalWaypoint.heading)
         XCTAssertEqual(decodedWaypoint.headingAccuracy, originalWaypoint.headingAccuracy)
         XCTAssertEqual(decodedWaypoint.allowsArrivingOnOppositeSide, originalWaypoint.allowsArrivingOnOppositeSide)
+        XCTAssertEqual(decodedWaypoint.separatesLegs, originalWaypoint.separatesLegs)
+    }
+    
+    func testSeparatesLegs() {
+        let one = Waypoint(coordinate: CLLocationCoordinate2D(latitude: 1, longitude: 1))
+        let two = Waypoint(coordinate: CLLocationCoordinate2D(latitude: 2, longitude: 2))
+        let three = Waypoint(coordinate: CLLocationCoordinate2D(latitude: 3, longitude: 3))
+        let four = Waypoint(coordinate: CLLocationCoordinate2D(latitude: 4, longitude: 4))
+        
+        let routeOptions = RouteOptions(waypoints: [one, two, three, four])
+        let matchOptions = MatchOptions(waypoints: [one, two, three, four], profileIdentifier: nil)
+        
+        XCTAssertNil(routeOptions.params.first { $0.name == "waypoints" }?.value)
+        XCTAssertNil(matchOptions.params.first { $0.name == "waypoints" }?.value)
+        
+        two.separatesLegs = false
+        
+        XCTAssertEqual(routeOptions.params.first { $0.name == "waypoints" }?.value, "0;2;3")
+        XCTAssertEqual(matchOptions.params.first { $0.name == "waypoints" }?.value, "0;2;3")
+        
+        two.separatesLegs = true
+        matchOptions.waypointIndices = [0, 2, 3]
+        
+        XCTAssertEqual(matchOptions.params.first { $0.name == "waypoints" }?.value, "0;2;3")
     }
 }


### PR DESCRIPTION
Added the `Waypoint.separatesLegs` property, which you can set to `false` to create a route that travels “via” the waypoint but doesn’t stop there. Deprecated the `MatchOptions.waypointIndices` property in favor of `Waypoint.separatesLegs`, which also works with `RouteOptions`.

Fixed unset properties in  `Waypoint` objects that are included in a calculated `Route`s or `Match`es by copying objects.

[![](https://upload.wikimedia.org/wikipedia/commons/thumb/3/32/Loch_nan_uamh_viaduct.jpg/640px-Loch_nan_uamh_viaduct.jpg)](https://commons.wikimedia.org/wiki/File:Loch_nan_uamh_viaduct.jpg)

Fixes #334.

/cc @mapbox/navigation-ios