### PR TITLE
Send large payloads in POST requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master
 
+* If a `RouteOptions` object has exceptionally many waypoints or if many of the waypoint have very long names, `Directions.calculate(_:completionHandler:)` sends a POST request to the Mapbox Directions API instead of sending a GET request that returns an error. ([#341](https://github.com/mapbox/MapboxDirections.swift/pull/341))
+* When possible, `Directions.calculateRoutes(matching:completionHandler:)` now sends a GET request to the Mapbox Map Matching API instead of a POST request. ([#341](https://github.com/mapbox/MapboxDirections.swift/pull/341))
+* Fixed an issue where certain waypoint names would cause `Directions.calculateRoutes(matching:completionHandler:)` to return an error. ([#341](https://github.com/mapbox/MapboxDirections.swift/pull/341))
+* Added the `Directions.url(forCalculating:httpMethod:)` and `Directions.urlRequest(forCalculating:)` methods for implementing custom GET- and POST-compatible request code. ([#341](https://github.com/mapbox/MapboxDirections.swift/pull/341))
 * Added the `Waypoint.separatesLegs` property, which you can set to `false` to create a route that travels “via” the waypoint but doesn’t stop there. Deprecated the `MatchOptions.waypointIndices` property in favor of `Waypoint.separatesLegs`, which also works with `RouteOptions`. ([#340](https://github.com/mapbox/MapboxDirections.swift/pull/340]))
 * Fixed unset properties in  `Waypoint` objects that are included in a calculated `Route`s or `Match`es. ([#340](https://github.com/mapbox/MapboxDirections.swift/pull/340]))
 * Added `DirectionsResult.fetchStartDate` and `DirectionsResult.requestEndDate` properties. ([#335](https://github.com/mapbox/MapboxDirections.swift/pull/335))

--- a/MapboxDirections/MBRouteOptions.swift
+++ b/MapboxDirections/MBRouteOptions.swift
@@ -72,14 +72,8 @@ open class RouteOptions: DirectionsOptions {
         coder.encode(roadClassesToAvoid.description, forKey: "roadClassesToAvoid")
     }
 
-    /**
-     The path of the request URL, not including the hostname or any parameters.
-     */
-    internal override var path: String {
-        assert(!queries.isEmpty, "No query")
-
-        let queryComponent = queries.joined(separator: ";")
-        return "directions/v5/\(profileIdentifier.rawValue)/\(queryComponent).json"
+    internal override var abridgedPath: String {
+        return "directions/v5/\(profileIdentifier.rawValue)"
     }
 
     /**
@@ -237,13 +231,10 @@ open class RouteOptionsV4: RouteOptions {
      The default value of this property is `true`.
      */
     @objc open var includesShapes: Bool = true
-
-    override var path: String {
-        assert(!queries.isEmpty, "No query")
-
+    
+    internal override var abridgedPath: String {
         let profileIdentifier = self.profileIdentifier.rawValue.replacingOccurrences(of: "/", with: ".")
-        let queryComponent = queries.joined(separator: ";")
-        return "v4/directions/\(profileIdentifier)/\(queryComponent).json"
+        return "v4/directions/\(profileIdentifier)"
     }
 
     override var params: [URLQueryItem] {

--- a/MapboxDirections/Match/MBMatchOptions.swift
+++ b/MapboxDirections/Match/MBMatchOptions.swift
@@ -87,19 +87,8 @@ open class MatchOptions: DirectionsOptions {
         return params
     }
 
-    internal override var path: String {
+    internal override var abridgedPath: String {
         return "matching/v5/\(profileIdentifier.rawValue)"
-    }
-
-    internal var encodedParam: String {
-        let joinedParams = params.compactMap({ (param) -> String? in
-            guard let value = param.value else { return nil }
-            return "\(param.name)=\(value)"
-        }).joined(separator: "&")
-
-        let locations = waypoints.map { "\($0.coordinate.longitude),\($0.coordinate.latitude)" }.joined(separator: ";")
-
-        return "\(joinedParams)&coordinates=\(locations)"
     }
 
     internal func response(from json: JSONDictionary) -> [Match]? {

--- a/MapboxDirectionsTests/MatchTests.swift
+++ b/MapboxDirectionsTests/MatchTests.swift
@@ -19,8 +19,8 @@ class MatchTests: XCTestCase {
                          CLLocationCoordinate2D(latitude: 32.712546, longitude: -117.173345)]
         
         stub(condition: isHost("api.mapbox.com")
-            && isMethodPOST()
-            && isPath("/matching/v5/mapbox/driving")) { _ in
+            && isMethodGET()
+            && pathStartsWith("/matching/v5/mapbox/driving")) { _ in
                 let path = Bundle(for: type(of: self)).path(forResource: "match", ofType: "json")
                 return OHHTTPStubsResponse(fileAtPath: path!, statusCode: 200, headers: ["Content-Type": "application/json"])
         }
@@ -107,8 +107,8 @@ class MatchTests: XCTestCase {
                          CLLocationCoordinate2D(latitude: 32.712546, longitude: -117.173345)]
         
         stub(condition: isHost("api.mapbox.com")
-            && isMethodPOST()
-            && isPath("/matching/v5/mapbox/driving")) { _ in
+            && isMethodGET()
+            && pathStartsWith("/matching/v5/mapbox/driving")) { _ in
                 let path = Bundle(for: type(of: self)).path(forResource: "null-tracepoint", ofType: "json")
                 return OHHTTPStubsResponse(fileAtPath: path!, statusCode: 200, headers: ["Content-Type": "application/json"])
         }

--- a/MapboxDirectionsTests/RoutableMatchTests.swift
+++ b/MapboxDirectionsTests/RoutableMatchTests.swift
@@ -19,8 +19,8 @@ class RoutableMatchTest: XCTestCase {
                          CLLocationCoordinate2D(latitude: 32.712546, longitude: -117.173345)]
         
         stub(condition: isHost("api.mapbox.com")
-            && isMethodPOST()
-            && isPath("/matching/v5/mapbox/driving")) { _ in
+            && isMethodGET()
+            && pathStartsWith("/matching/v5/mapbox/driving")) { _ in
                 let path = Bundle(for: type(of: self)).path(forResource: "match", ofType: "json")
                 return OHHTTPStubsResponse(fileAtPath: path!, statusCode: 200, headers: ["Content-Type": "application/json"])
         }


### PR DESCRIPTION
Unified RouteOptions and MatchOptions URL and URL request creation logic. Now the decision of whether to send a GET or POST request is based on the overall URL length, not based on the API endpoint.

Fixed an issue where waypoint names were left unescaped in the body of a POST request to the Map Matching API.

Added methods to get a request or request URL appropriate to the HTTP request method being used.

Fixes #338.

/cc @mapbox/navigation-ios @danpat