### PR TITLE
Extensible URL query items

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * Added the `Waypoint.separatesLegs` property, which you can set to `false` to create a route that travels “via” the waypoint but doesn’t stop there. Deprecated the `MatchOptions.waypointIndices` property in favor of `Waypoint.separatesLegs`, which also works with `RouteOptions`. ([#340](https://github.com/mapbox/MapboxDirections.swift/pull/340]))
 * Fixed unset properties in  `Waypoint` objects that are included in a calculated `Route`s or `Match`es. ([#340](https://github.com/mapbox/MapboxDirections.swift/pull/340]))
 * Added `DirectionsResult.fetchStartDate` and `DirectionsResult.requestEndDate` properties. ([#335](https://github.com/mapbox/MapboxDirections.swift/pull/335))
+* Added a `DirectionsOptions.urlQueryItems` property so that subclasses of `RouteOptions` and `MatchOptions` can add any additional URL query parameters that are supported by the Mapbox Directions and Map Matching APIs. ([#343](https://github.com/mapbox/MapboxDirections.swift/pull/343)) 
 
 ## v0.26.1
 

--- a/MapboxDirections/MBDirections.swift
+++ b/MapboxDirections/MBDirections.swift
@@ -281,13 +281,13 @@ open class Directions: NSObject {
     @objc(URLForCalculatingDirectionsWithOptions:HTTPMethod:)
     open func url(forCalculating options: DirectionsOptions, httpMethod: String) -> URL {
         let includesQuery = httpMethod != "POST"
-        let params = (includesQuery ? options.params : []) + [
+        let queryItems = (includesQuery ? options.urlQueryItems : []) + [
             URLQueryItem(name: "access_token", value: accessToken),
         ]
 
         let unparameterizedURL = URL(string: includesQuery ? options.path : options.abridgedPath, relativeTo: apiEndpoint)!
         var components = URLComponents(url: unparameterizedURL, resolvingAgainstBaseURL: true)!
-        components.queryItems = params
+        components.queryItems = queryItems
         return components.url!
     }
     
@@ -308,7 +308,7 @@ open class Directions: NSObject {
         if getURL.absoluteString.count > MaximumURLLength {
             request.url = url(forCalculating: options, httpMethod: "POST")
             
-            let body = options.encodedParams.data(using: .utf8)
+            let body = options.httpBody.data(using: .utf8)
             request.setValue("application/x-www-form-urlencoded", forHTTPHeaderField: "Content-Type")
             request.httpMethod = "POST"
             request.httpBody = body

--- a/MapboxDirections/MBRouteOptions.swift
+++ b/MapboxDirections/MBRouteOptions.swift
@@ -112,19 +112,16 @@ open class RouteOptions: DirectionsOptions {
      */
     @objc open var roadClassesToAvoid: RoadClasses = []
 
-    /**
-     An array of URL parameters to include in the request URL.
-     */
-    internal override var params: [URLQueryItem] {
-        var params = super.params
+    override open var urlQueryItems: [URLQueryItem] {
+        var queryItems = super.urlQueryItems
 
-        params.append(contentsOf: [
+        queryItems.append(contentsOf: [
             URLQueryItem(name: "alternatives", value: String(includesAlternativeRoutes)),
             URLQueryItem(name: "continue_straight", value: String(!allowsUTurnAtWaypoint))
         ])
 
         if includesExitRoundaboutManeuver {
-            params.append(URLQueryItem(name: "roundabout_exits", value: String(includesExitRoundaboutManeuver)))
+            queryItems.append(URLQueryItem(name: "roundabout_exits", value: String(includesExitRoundaboutManeuver)))
         }
 
         if !roadClassesToAvoid.isEmpty {
@@ -133,16 +130,16 @@ open class RouteOptions: DirectionsOptions {
                 assert(false, "`roadClassesToAvoid` only accepts one `RoadClasses`.")
             }
             if let firstRoadClass = allRoadClasses.first {
-                params.append(URLQueryItem(name: "exclude", value: firstRoadClass))
+                queryItems.append(URLQueryItem(name: "exclude", value: firstRoadClass))
             }
         }
 
         if waypoints.first(where: { CLLocationCoordinate2DIsValid($0.targetCoordinate) }) != nil {
             let targetCoordinates = waypoints.map { $0.targetCoordinate.stringForRequestURL ?? "" }.joined(separator: ";")
-            params.append(URLQueryItem(name: "waypoint_targets", value: targetCoordinates))
+            queryItems.append(URLQueryItem(name: "waypoint_targets", value: targetCoordinates))
         }
 
-        return params
+        return queryItems
     }
 
     /**
@@ -237,7 +234,7 @@ open class RouteOptionsV4: RouteOptions {
         return "v4/directions/\(profileIdentifier)"
     }
 
-    override var params: [URLQueryItem] {
+    override open var urlQueryItems: [URLQueryItem] {
         return [
             URLQueryItem(name: "alternatives", value: String(includesAlternativeRoutes)),
             URLQueryItem(name: "instructions", value: String(describing: instructionFormat)),

--- a/MapboxDirections/Match/MBMatchOptions.swift
+++ b/MapboxDirections/Match/MBMatchOptions.swift
@@ -73,18 +73,18 @@ open class MatchOptions: DirectionsOptions {
         return true
     }
 
-    override internal var params: [URLQueryItem] {
-        var params = super.params
+    override open var urlQueryItems: [URLQueryItem] {
+        var queryItems = super.urlQueryItems
 
-        params.append(URLQueryItem(name: "tidy", value: String(describing: resamplesTraces)))
+        queryItems.append(URLQueryItem(name: "tidy", value: String(describing: resamplesTraces)))
 
         if let waypointIndices = (self as MatchOptionsDeprecations).waypointIndices {
-            params.append(URLQueryItem(name: "waypoints", value: waypointIndices.map {
+            queryItems.append(URLQueryItem(name: "waypoints", value: waypointIndices.map {
                 String(describing: $0)
             }.joined(separator: ";")))
         }
 
-        return params
+        return queryItems
     }
 
     internal override var abridgedPath: String {

--- a/MapboxDirectionsTests/RouteOptionsTests.swift
+++ b/MapboxDirectionsTests/RouteOptionsTests.swift
@@ -93,8 +93,8 @@ class RouteOptionsTests: XCTestCase {
         
         let routeOptions = RouteOptions(waypoints: waypoints)
         routeOptions.includesSteps = true
-        let params = routeOptions.params
-        let approaches = params.filter { $0.name == "approaches" }.first!
+        let urlQueryItems = routeOptions.urlQueryItems
+        let approaches = urlQueryItems.filter { $0.name == "approaches" }.first!
         XCTAssertEqual(approaches.value!, "unrestricted;curb;unrestricted", "waypoints[1] should be restricted to curb")
     }
     
@@ -108,8 +108,8 @@ class RouteOptionsTests: XCTestCase {
         
         let routeOptions = RouteOptions(waypoints: waypoints)
         routeOptions.includesSteps = true
-        let params = routeOptions.params
-        let hasApproaches = !params.filter { $0.name == "approaches" }.isEmpty
+        let urlQueryItems = routeOptions.urlQueryItems
+        let hasApproaches = !urlQueryItems.filter { $0.name == "approaches" }.isEmpty
         XCTAssertFalse(hasApproaches, "approaches query param should be omitted unless any waypoint is restricted to curb")
     }
     
@@ -134,8 +134,8 @@ class RouteOptionsTests: XCTestCase {
         let options = RouteOptions(waypoints: [origin, destination])
         
         XCTAssertEqual(options.queries, ["-84.47182,39.15031", "-84.51638,39.12971"])
-        XCTAssertTrue(options.params.contains(URLQueryItem(name: "waypoint_names", value: "XU;UC")))
-        XCTAssertTrue(options.params.contains(URLQueryItem(name: "waypoint_targets", value: ";-84.51619,39.13115")))
+        XCTAssertTrue(options.urlQueryItems.contains(URLQueryItem(name: "waypoint_names", value: "XU;UC")))
+        XCTAssertTrue(options.urlQueryItems.contains(URLQueryItem(name: "waypoint_targets", value: ";-84.51619,39.13115")))
     }
 }
 

--- a/MapboxDirectionsTests/WaypointTests.swift
+++ b/MapboxDirectionsTests/WaypointTests.swift
@@ -66,17 +66,17 @@ class WaypointTests: XCTestCase {
         let routeOptions = RouteOptions(waypoints: [one, two, three, four])
         let matchOptions = MatchOptions(waypoints: [one, two, three, four], profileIdentifier: nil)
         
-        XCTAssertNil(routeOptions.params.first { $0.name == "waypoints" }?.value)
-        XCTAssertNil(matchOptions.params.first { $0.name == "waypoints" }?.value)
+        XCTAssertNil(routeOptions.urlQueryItems.first { $0.name == "waypoints" }?.value)
+        XCTAssertNil(matchOptions.urlQueryItems.first { $0.name == "waypoints" }?.value)
         
         two.separatesLegs = false
         
-        XCTAssertEqual(routeOptions.params.first { $0.name == "waypoints" }?.value, "0;2;3")
-        XCTAssertEqual(matchOptions.params.first { $0.name == "waypoints" }?.value, "0;2;3")
+        XCTAssertEqual(routeOptions.urlQueryItems.first { $0.name == "waypoints" }?.value, "0;2;3")
+        XCTAssertEqual(matchOptions.urlQueryItems.first { $0.name == "waypoints" }?.value, "0;2;3")
         
         two.separatesLegs = true
         matchOptions.waypointIndices = [0, 2, 3]
         
-        XCTAssertEqual(matchOptions.params.first { $0.name == "waypoints" }?.value, "0;2;3")
+        XCTAssertEqual(matchOptions.urlQueryItems.first { $0.name == "waypoints" }?.value, "0;2;3")
     }
 }


### PR DESCRIPTION
Renamed `DirectionsOptions.params` to `urlQueryItems` and made it `open` so that subclasses of `RouteOptions` and `MatchOptions` can add any additional URL query parameters that are supported by the Mapbox Directions and Map Matching APIs.

Fixes #339.

/cc @mapbox/navigation-ios @taraniduncan