### PR TITLE
Fix malformed coordinate bounds in routing tile pack request URL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changes to the Mapbox Directions SDK for iOS
 
+## v0.27.1
+
+* Fixed an issue where `Directions.downloadTiles(in:version:session:completionHandler:)` always failed with an error after passing in a `CoordinateBounds` created using the `CoordinateBounds(northWest:southEast:)` initializer. ([#349](https://github.com/mapbox/MapboxDirections.swift/pull/349))
+* Added a `CoordinateBounds(southWest:northEast:)` initializer. ([#349](https://github.com/mapbox/MapboxDirections.swift/pull/349))
+
 ## v0.27.0
 
 * If a `RouteOptions` object has exceptionally many waypoints or if many of the waypoint have very long names, `Directions.calculate(_:completionHandler:)` sends a POST request to the Mapbox Directions API instead of sending a GET request that returns an error. ([#341](https://github.com/mapbox/MapboxDirections.swift/pull/341))

--- a/MapboxDirections/MBCoordinateBounds.swift
+++ b/MapboxDirections/MBCoordinateBounds.swift
@@ -6,16 +6,26 @@ import CoreLocation
  */
 @objc(MBCoordinateBounds)
 public class CoordinateBounds: NSObject, Codable {
-    let northWest: CLLocationCoordinate2D
-    let southEast: CLLocationCoordinate2D
+    let southWest: CLLocationCoordinate2D
+    let northEast: CLLocationCoordinate2D
+    
+    /**
+     Initializes a `BoundingBox` with known bounds.
+     */
+    @objc
+    public init(southWest: CLLocationCoordinate2D, northEast: CLLocationCoordinate2D) {
+        self.southWest = southWest
+        self.northEast = northEast
+        super.init()
+    }
     
     /**
      Initializes a `BoundingBox` with known bounds.
      */
     @objc
     public init(northWest: CLLocationCoordinate2D, southEast: CLLocationCoordinate2D) {
-        self.northWest = northWest
-        self.southEast = southEast
+        self.southWest = CLLocationCoordinate2D(latitude: southEast.latitude, longitude: northWest.longitude)
+        self.northEast = CLLocationCoordinate2D(latitude: northWest.latitude, longitude: southEast.longitude)
         super.init()
     }
     
@@ -32,20 +42,20 @@ public class CoordinateBounds: NSObject, Codable {
         var minimumLongitude: CLLocationDegrees = 180
         
         for coordinate in coordinates {
-            maximumLatitude = Swift.max(maximumLatitude, coordinate.latitude)
-            minimumLatitude = Swift.min(minimumLatitude, coordinate.latitude)
-            maximumLongitude = Swift.max(maximumLongitude, coordinate.longitude)
-            minimumLongitude = Swift.min(minimumLongitude, coordinate.longitude)
+            maximumLatitude = max(maximumLatitude, coordinate.latitude)
+            minimumLatitude = min(minimumLatitude, coordinate.latitude)
+            maximumLongitude = max(maximumLongitude, coordinate.longitude)
+            minimumLongitude = min(minimumLongitude, coordinate.longitude)
         }
         
-        let northWest = CLLocationCoordinate2D(latitude: minimumLatitude, longitude: minimumLongitude)
-        let southEast = CLLocationCoordinate2D(latitude: maximumLatitude, longitude: maximumLongitude)
+        let southWest = CLLocationCoordinate2D(latitude: minimumLatitude, longitude: minimumLongitude)
+        let northEast = CLLocationCoordinate2D(latitude: maximumLatitude, longitude: maximumLongitude)
         
-        self.init(northWest: northWest, southEast: southEast)
+        self.init(southWest: southWest, northEast: northEast)
     }
     
-    var path: String {
-        return "\(northWest.longitude),\(northWest.latitude);\(southEast.longitude),\(southEast.latitude)"
+    public override var description: String {
+        return "\(southWest.longitude),\(southWest.latitude);\(northEast.longitude),\(northEast.latitude)"
     }
 }
 

--- a/MapboxDirections/OfflineDirections.swift
+++ b/MapboxDirections/OfflineDirections.swift
@@ -45,7 +45,7 @@ extension Directions: OfflineDirectionsProtocol {
     /// URL to the endpoint for downloading a tile pack
     public func tilesURL(for coordinateBounds: CoordinateBounds, version: OfflineVersion) -> URL {
         
-        let url = apiEndpoint.appendingPathComponent("route-tiles/v1").appendingPathComponent(coordinateBounds.path)
+        let url = apiEndpoint.appendingPathComponent("route-tiles/v1").appendingPathComponent(coordinateBounds.description)
         var components = URLComponents(url: url, resolvingAgainstBaseURL: true)
         components?.queryItems = [URLQueryItem(name: "version", value: version),
                                   URLQueryItem(name: "access_token", value: accessToken)]

--- a/MapboxDirectionsTests/OfflineDirectionsTests.swift
+++ b/MapboxDirectionsTests/OfflineDirectionsTests.swift
@@ -35,6 +35,16 @@ class OfflineDirectionsTests: XCTestCase {
         
         wait(for: [versionsExpectation], timeout: 2)
     }
+    
+    func testCoordinateBounds() {
+        let bounds = CoordinateBounds(coordinates: [CLLocationCoordinate2D(latitude: 37.7890, longitude: -122.4337),
+                                                    CLLocationCoordinate2D(latitude: 37.7881, longitude: -122.4318)])
+        XCTAssertEqual(bounds.southWest.latitude, 37.7881)
+        XCTAssertEqual(bounds.southWest.longitude, -122.4337)
+        XCTAssertEqual(bounds.northEast.latitude, 37.7890)
+        XCTAssertEqual(bounds.northEast.longitude, -122.4318)
+        XCTAssertEqual(bounds.description, "-122.4337,37.7881;-122.4318,37.789")
+    }
 
     func testDownloadTiles() {
         


### PR DESCRIPTION
Fixed a mixup in the implementation of CoordinateBounds that caused `Directions.downloadTiles(in:version:session:completionHandler:)` to error out. Added a `CoordinateBounds(southWest:northEast:)` initializer for completeness.

Fixes #348.

/cc @mapbox/navigation-ios