### PR TITLE
Sort offline versions in descending chronological order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,10 @@
 # Changes to the Mapbox Directions SDK for iOS
 
-## v0.27.1
+## master
 
 * Fixed an issue where `Directions.downloadTiles(in:version:session:completionHandler:)` always failed with an error after passing in a `CoordinateBounds` created using the `CoordinateBounds(northWest:southEast:)` initializer. ([#349](https://github.com/mapbox/MapboxDirections.swift/pull/349))
 * Added a `CoordinateBounds(southWest:northEast:)` initializer. ([#349](https://github.com/mapbox/MapboxDirections.swift/pull/349))
+* The versions passed into the completion handler of `Directions.fetchAvailableOfflineVersions(completionHandler:)` are now sorted in reverse chronological order. ([#350](https://github.com/mapbox/MapboxDirections.swift/pull/350))
 
 ## v0.27.0
 

--- a/MapboxDirections/OfflineDirections.swift
+++ b/MapboxDirections/OfflineDirections.swift
@@ -54,7 +54,7 @@ extension Directions: OfflineDirectionsProtocol {
     }
 
     /**
-     Fetch the available versions. A version is represented as a String (yyyy-MM-dd or yyyy-MM-dd-x).
+     Fetch the available versions in descending chronological order. A version is represented as a String (yyyy-MM-dd or yyyy-MM-dd-x).
      
      - parameter completionHandler: The closure to call with the results
      - returns: A `URLSessionDataTask`
@@ -73,7 +73,8 @@ extension Directions: OfflineDirectionsProtocol {
             
             do {
                 let versionResponse = try JSONDecoder().decode(AvailableVersionsResponse.self, from: data)
-                completionHandler(versionResponse.availableVersions, error)
+                let availableVersions = versionResponse.availableVersions.sorted(by: >)
+                completionHandler(availableVersions, error)
             } catch {
                 completionHandler(nil, error)
             }


### PR DESCRIPTION
For convenience’s sake, the versions passed into the completion handler of `Directions.fetchAvailableOfflineVersions(completionHandler:)` are now sorted in descending chronological order.

/cc @mapbox/navigation-ios @allierowan