### PR TITLE
Update documentation updating script

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,8 +1,3 @@
 ## Generating documentation locally
 
 Make sure you’ve got the latest version of jazzy installed, then run `scripts/document.sh`.
-
-## Update the documentation site:
-1. Clone [mapbox-navigation-ios](https://github.com/mapbox/mapbox-navigation-ios) to a mapbox-navigation-ios-docs folder alongside your MapboxDirections.swift clone, and check out the `mb-pages` branch.
-1. In your main MapboxDirections.swift clone, check out the release branch and run `OUTPUT=../mapbox-navigation-ios-docs/directions VERSION=X.X.X scripts/document.sh`, where _X.X.X_ is the new SDK version.
-1. Commit and push your changes to the mapbox-navigation-ios `mb-pages` branch.

--- a/docs/cover.md
+++ b/docs/cover.md
@@ -1,0 +1,35 @@
+# [MapboxDirections.swift](https://docs.mapbox.com/ios/directions/)
+
+MapboxDirections.swift makes it easy to connect your iOS, macOS, tvOS, or watchOS application to the [Mapbox Directions](https://docs.mapbox.com/api/navigation/) and [Map Matching](https://docs.mapbox.com/api/navigation/#map-matching) APIs. Quickly get driving, cycling, or walking directions, whether the trip is nonstop or it has multiple stopping points, all using a simple interface reminiscent of MapKit’s `MKDirections` API. Fit a GPX trace to the [OpenStreetMap](https://www.openstreetmap.org/) road network. The Mapbox Directions and Map Matching APIs are powered by the [OSRM](http://project-osrm.org/) routing engine. For more information, see the [Mapbox Navigation](https://www.mapbox.com/navigation/) homepage.
+
+Despite its name, MapboxDirections.swift works in Objective-C and Cocoa-AppleScript code in addition to Swift 4.
+
+MapboxDirections.swift pairs well with [MapboxGeocoder.swift](https://github.com/mapbox/MapboxGeocoder.swift), [MapboxStatic.swift](https://github.com/mapbox/MapboxStatic.swift), the [Mapbox Navigation SDK for iOS](https://github.com/mapbox/mapbox-navigation-ios/), and the [Mapbox Maps SDK for iOS](https://docs.mapbox.com/ios/maps/) or [macOS SDK](https://mapbox.github.io/mapbox-gl-native/macos/).
+
+## Installation
+
+Specify the following dependency in your [Carthage](https://github.com/Carthage/Carthage) Cartfile:
+
+```cartfile
+github "mapbox/MapboxDirections.swift" ~> ${MINOR_VERSION}
+```
+
+Or in your [CocoaPods](http://cocoapods.org/) Podfile:
+
+```podspec
+pod 'MapboxDirections.swift', '~> ${MINOR_VERSION}'
+```
+
+Then `import MapboxDirections` or `@import MapboxDirections;`.
+
+## Configuration
+
+You’ll need a [Mapbox access token](https://docs.mapbox.com/api/#access-tokens-and-token-scopes) in order to use the API. If you’re already using the [Mapbox Maps SDK for iOS](https://docs.mapbox.com/ios/maps/) or [macOS SDK](https://mapbox.github.io/mapbox-gl-native/macos/), MapboxDirections.swift automatically recognizes your access token, as long as you’ve placed it in the `MGLMapboxAccessToken` key of your application’s Info.plist file.
+
+## Starting points
+
+`Directions` is the main class that represents the Mapbox Directions and Map Matching APIs. To calculate directions between coordinates, configure a `RouteOptions` object and pass it into `Directions.calculate(_:completionHandler:)`. Similarly, to match a trace to the road network, configure a `MatchOptions` object and pass it into either `Directions.calculate(_:completionHandler:)` or `Directions.calculateRoutes(matching:completionHandler:)`. These methods asynchronously send requests to the API, then form `Route` or `Match` objects that correspond to the API’s response.
+
+A `Route` object is composed of one or more `RouteLeg`s between waypoints, which in turn are composed of one or more `RouteStep`s between maneuvers. Depending on the request, a `RouteStep` may additionally contain objects representing intersection- and segment-level data. A `Match` object is structured similarly, except that it provides additional details about how the trace matches the road network.
+
+For further details, consult the guides and examples included with this API reference. To integrate real-time turn-by-turn navigation into your iOS application, see “[Navigation SDK](navigation-sdk.html)”. If you have any questions, please see [our help page](https://docs.mapbox.com/help/). We welcome your [bug reports, feature requests, and contributions](https://github.com/mapbox/MapboxDirections.swift/).

--- a/docs/jazzy.yml
+++ b/docs/jazzy.yml
@@ -1,6 +1,6 @@
 module: MapboxDirections
 author: Mapbox
-author_url: https://www.mapbox.com/navigation/
+author_url: https://docs.mapbox.com/ios/directions/
 github_url: https://github.com/mapbox/MapboxDirections.swift
 dash_url: https://docs.mapbox.com/ios/docsets/MapboxDirections.xml
 copyright: '© 2014–2019 [Mapbox](https://www.mapbox.com/). See [license](https://github.com/mapbox/MapboxDirections.swift/blob/master/LICENSE.md) for more details.'


### PR DESCRIPTION
Synchronized the documentation updating script with the one for the navigation SDK. Added a cover page largely based on the readme, but with the addition of a “Starting points” section that provides a brief overview of the library’s structure.

/cc @mapbox/navigation-ios @colleenmcginnis