### PR TITLE
Add support for speed limits via maxspeed annotations.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changes to MapboxDirections.swift
 
+## master
+
+* Added support for maxspeed annotations from the Directions API. ([#367](https://github.com/mapbox/MapboxDirections.swift/pull/367))
+
 ## v0.30.0
 
 * `Directions.fetchAvailableOfflineVersions(completionHandler:)` and `Directions.downloadTiles(in:version:completionHandler:)` now resumes the data task before returning it to conform to its naming conventions and avoid confusion. ([#353](https://github.com/mapbox/MapboxDirections.swift/pull/353))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## master
 
-* Added support for maxspeed annotations from the Directions API. ([#367](https://github.com/mapbox/MapboxDirections.swift/pull/367))
+* Added `AttributeOptions.maximumSpeedLimit` for getting maximum posted speed limits in the `RouteLeg.segmentMaximumSpeedLimits` property. ([#367](https://github.com/mapbox/MapboxDirections.swift/pull/367))
 
 ## v0.30.0
 

--- a/Directions Example/ViewController.swift
+++ b/Directions Example/ViewController.swift
@@ -76,6 +76,8 @@ class ViewController: UIViewController, MBDrawingViewDelegate {
         wp2.allowsArrivingOnOppositeSide = false
         let options = RouteOptions(waypoints: [wp1, wp2])
         options.includesSteps = true
+        options.routeShapeResolution = .full
+        options.attributeOptions = [.congestionLevel, .maximumSpeedLimit]
         
         Directions(accessToken: MapboxAccessToken).calculate(options) { (waypoints, routes, error) in
             guard error == nil else {

--- a/MapboxDirections.xcodeproj/project.pbxproj
+++ b/MapboxDirections.xcodeproj/project.pbxproj
@@ -274,6 +274,7 @@
 		F448F8401DDCC709000BC343 /* Polyline.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F448F83C1DDCC6F3000BC343 /* Polyline.framework */; };
 		F448F8411DDCC70C000BC343 /* OHHTTPStubs.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F448F83B1DDCC6F3000BC343 /* OHHTTPStubs.framework */; };
 		F448F8421DDCC70D000BC343 /* Polyline.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F448F83C1DDCC6F3000BC343 /* Polyline.framework */; };
+		F4B0022A22650A9F00CF44FF /* MapboxDirections.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = DA6C9D881CAE442B00094FBC /* MapboxDirections.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		F4D785EF1DDD82C100FF4665 /* RouteStepTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4D785EE1DDD82C100FF4665 /* RouteStepTests.swift */; };
 		F4D785F01DDD82C100FF4665 /* RouteStepTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4D785EE1DDD82C100FF4665 /* RouteStepTests.swift */; };
 		F4D785F11DDD82C100FF4665 /* RouteStepTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4D785EE1DDD82C100FF4665 /* RouteStepTests.swift */; };
@@ -317,6 +318,7 @@
 			dstPath = "";
 			dstSubfolderSpec = 10;
 			files = (
+				F4B0022A22650A9F00CF44FF /* MapboxDirections.framework in Embed Frameworks */,
 			);
 			name = "Embed Frameworks";
 			runOnlyForDeploymentPostprocessing = 0;
@@ -1252,7 +1254,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "/usr/local/bin/carthage copy-frameworks";
+			shellScript = "/usr/local/bin/carthage copy-frameworks\n";
 		};
 		DADD27F61E5AC7FA00D31FAD /* Copy Frameworks */ = {
 			isa = PBXShellScriptBuildPhase;

--- a/Sources/CMapboxDirections/include/MBAttribute.h
+++ b/Sources/CMapboxDirections/include/MBAttribute.h
@@ -39,7 +39,7 @@ typedef NS_OPTIONS(NSUInteger, MBAttributeOptions) {
     /**
      The maximum speed limit along the segment.
      
-     When this attribute is specified, the `RouteLeg.congestionLevels` property contains one value for each segment in the leg’s full geometry.
+     When this attribute is specified, the `RouteLeg.segmentMaximumSpeedLimits` property contains one value for each segment in the leg’s full geometry.
      */
     MBAttributeMaximumSpeedLimit = (1 << 5),
 };

--- a/Sources/CMapboxDirections/include/MBAttribute.h
+++ b/Sources/CMapboxDirections/include/MBAttribute.h
@@ -41,5 +41,5 @@ typedef NS_OPTIONS(NSUInteger, MBAttributeOptions) {
      
      When this attribute is specified, the `RouteLeg.congestionLevels` property contains one value for each segment in the leg’s full geometry.
      */
-    MBAttributeMaximumSpeedLimit = (1 << 6),
+    MBAttributeMaximumSpeedLimit = (1 << 5),
 };

--- a/Sources/MapboxDirections/MBRouteLeg.swift
+++ b/Sources/MapboxDirections/MBRouteLeg.swift
@@ -192,6 +192,8 @@ open class RouteLeg: NSObject, NSSecureCoding {
 
     /**
      An array containing the maximum speed limit along each road segment along the route leg’s shape.
+     
+     The maximum speed may be an advisory speed limit for segments where legal limits are not posted, such as highway entrance and exit ramps.
 
      Speed limit data is available in [a number of countries and territories worldwide](https://docs.mapbox.com/help/how-mapbox-works/directions/).
 

--- a/Sources/MapboxDirections/MBRouteLeg.swift
+++ b/Sources/MapboxDirections/MBRouteLeg.swift
@@ -192,6 +192,10 @@ open class RouteLeg: NSObject, NSSecureCoding {
 
     /**
      An array containing the maximum speed limit along each road segment along the route leg’s shape.
+
+     Speed limit data is available in [a number of countries and territories worldwide](https://docs.mapbox.com/help/how-mapbox-works/directions/).
+
+     This property is set if the `RouteOptions.attributeOptions` property contains `.maximumSpeedLimit`.
      */
     @objc public let segmentMaximumSpeedLimits: [SpeedLimit]?
     

--- a/Sources/MapboxDirections/MBSpeedLimit.swift
+++ b/Sources/MapboxDirections/MBSpeedLimit.swift
@@ -1,22 +1,26 @@
 import Foundation
 
 /**
- A localized limit for measuring speed limits.
+ A `SpeedLimit` represents a bound on velocity that is in place for regulatory or safety reasons.
+
+ It includes a numeric value as well as the measurement units used for velocity.
+
+ A speed limit could indicate either an upper or lower bound for velocity.
  */
 @objc(MBSpeedLimit)
 public class SpeedLimit: NSObject, NSSecureCoding {
     
     /**
-     Represents an unknown speed limit for a segment.
+     Represents an invalid or unknown speed limit.
      */
     @objc public static let invalid = SpeedLimit(value: -1, speedUnits: .kilometersPerHour)
     
     /**
-     A unitless measure of speed which is dependent on the `MaximumSpeedLimit.speedUnits`.
+     A unitless measure of speed which is dependent on the `SpeedLimit.unit`.
      
      By default, the speed will be unknown and equal to `SpeedLimit.invalid` which is -1.
      
-     If the speed is none, the value will be equal to `Double.greatestFiniteMagnitude`.
+     If there is no maximum speed limit, the property is set to `Double.greatestFiniteMagnitude`.
      */
     @objc public var value: Double = -1
     
@@ -69,6 +73,11 @@ public class SpeedLimit: NSObject, NSSecureCoding {
     public func encode(with coder: NSCoder) {
         coder.encode(value, forKey: "value")
         coder.encode(unit, forKey: "unit")
+    }
+
+    open override func isEqual(_ object: Any?) -> Bool {
+        guard let other = object as? SpeedLimit else { return false }
+        return other.unit == self.unit && other.value == self.value
     }
 }
 

--- a/Sources/MapboxDirections/MBSpeedLimit.swift
+++ b/Sources/MapboxDirections/MBSpeedLimit.swift
@@ -20,7 +20,7 @@ public class SpeedLimit: NSObject, NSSecureCoding {
      
      By default, the speed will be unknown and equal to `SpeedLimit.invalid` which is -1.
      
-     If there is no maximum speed limit, the property is set to `Double.greatestFiniteMagnitude`.
+     If there is no maximum speed limit, the property is set to `SpeedLimit.invalid.value`.
      */
     @objc public var value: Double = -1
     

--- a/Sources/MapboxDirections/MBSpeedLimit.swift
+++ b/Sources/MapboxDirections/MBSpeedLimit.swift
@@ -1,6 +1,5 @@
 import Foundation
 
-
 /**
  A localized limit for measuring speed limits.
  */
@@ -12,7 +11,6 @@ public class SpeedLimit: NSObject, NSSecureCoding {
      */
     @objc public static let invalid = SpeedLimit(value: -1, speedUnits: .kilometersPerHour)
     
-    
     /**
      A unitless measure of speed which is dependent on the `MaximumSpeedLimit.speedUnits`.
      
@@ -22,12 +20,10 @@ public class SpeedLimit: NSObject, NSSecureCoding {
      */
     @objc public var value: Double = -1
     
-    
     /**
      Units for `MaximumSpeedLimit.speed`.
      */
     @objc public var unit: SpeedUnit = .kilometersPerHour
-    
     
     /**
      Initialize a new `SpeedLimit` object.
@@ -37,24 +33,26 @@ public class SpeedLimit: NSObject, NSSecureCoding {
         self.unit = speedUnits
     }
 
-    
     /**
      Initialize a new `SpeedLimit` object from a JSON dictionary.
      */
     @objc public convenience init(json: [String: Any]) {
-        var speed = json["speed"] as? Double ?? -1
+        var speed = json["speed"] as? Double ?? SpeedLimit.invalid.value
+        if let speedUnknown = json["unknown"] as? Bool, speedUnknown {
+            speed = SpeedLimit.invalid.value
+        }
         if let speedNone = json["none"] as? Bool, speedNone {
             speed = .greatestFiniteMagnitude
         }
         
-        let speedUnits: SpeedUnit
-        if let speedString = json["unit"] as? String {
-            speedUnits = SpeedUnit(description: speedString) ?? .kilometersPerHour
+        let speedUnit: SpeedUnit
+        if let speedUnitString = json["unit"] as? String {
+            speedUnit = SpeedUnit(description: speedUnitString) ?? .kilometersPerHour
         } else {
-            speedUnits = .kilometersPerHour
+            speedUnit = .kilometersPerHour
         }
         
-        self.init(value: speed, speedUnits: speedUnits)
+        self.init(value: speed, speedUnits: speedUnit)
     }
     
     public static var supportsSecureCoding = true
@@ -62,10 +60,10 @@ public class SpeedLimit: NSObject, NSSecureCoding {
     public required init?(coder decoder: NSCoder) {
         value = decoder.decodeDouble(forKey: "value")
         
-        guard let speedUnitString = decoder.decodeObject(of: NSString.self, forKey: "unit") as String?, let speedUnits = SpeedUnit(description: speedUnitString) else {
+        guard let speedUnitString = decoder.decodeObject(of: NSString.self, forKey: "unit") as String?, let speedUnit = SpeedUnit(description: speedUnitString) else {
                 return nil
         }
-        self.unit = speedUnits
+        self.unit = speedUnit
     }
     
     public func encode(with coder: NSCoder) {
@@ -74,9 +72,8 @@ public class SpeedLimit: NSObject, NSSecureCoding {
     }
 }
 
-
 /**
- Units for measure `SpeedLimit`.
+ Unit of measurement for `SpeedLimit`.
  */
 @objc(MBSpeedUnits)
 public enum SpeedUnit: Int, CustomStringConvertible {
@@ -113,4 +110,3 @@ public enum SpeedUnit: Int, CustomStringConvertible {
         }
     }
 }
-

--- a/Tests/MapboxDirectionsTests/AnnotationTests.swift
+++ b/Tests/MapboxDirectionsTests/AnnotationTests.swift
@@ -83,8 +83,7 @@ class AnnotationTests: XCTestCase {
         XCTAssertEqual(SpeedLimit(json: ["speed": 80.0, "unit": "km/h"]).value, 80.0)
         XCTAssertEqual(SpeedLimit(json: ["speed": 80.0, "unit": "km/h"]).unit, .kilometersPerHour)
         
-        XCTAssertEqual(SpeedLimit(json: ["unknown": true]).value, SpeedLimit.invalid.value)
-        XCTAssertEqual(SpeedLimit(json: ["unknown": true]).unit, SpeedLimit.invalid.unit)
+        XCTAssertEqual(SpeedLimit(json: ["unknown": true]), SpeedLimit.invalid)
         
         XCTAssertEqual(SpeedLimit(json: ["none": true]).value, .greatestFiniteMagnitude)
         XCTAssertEqual(SpeedLimit(json: ["none": true]).unit, .kilometersPerHour)


### PR DESCRIPTION
Include SDK/API support for speed limits from the Directions API via the maxspeed annotations in the directions response.