### PR TITLE
Add string conversion methods for Objective-C

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changes to MapboxDirections.swift
 
+## master
+
+* Added the `MBStringFromManeuverType()`, `MBStringFromManeuverDirection()`, `MBStringFromDrivingSide()`, and `MBStringFromTransportType()` functions, which are intended for use in Objective-C. ([#369](https://github.com/mapbox/MapboxDirections.swift/pull/369))
+
 ## v0.27.3
 
 * Fixed compatibility issues with Xcode 10.2 when the SDK is installed using Carthage. ([#363](https://github.com/mapbox/MapboxDirections.swift/pull/363))

--- a/Directions Example/ViewController.m
+++ b/Directions Example/ViewController.m
@@ -57,9 +57,9 @@ NSString * const MapboxAccessToken = @"<# your Mapbox access token #>";
             NSLog(@"Distance: %@; ETA: %@", formattedDistance, formattedTravelTime);
             
             for (MBRouteStep *step in leg.steps) {
-                NSLog(@"%@", step.instructions);
+                NSLog(@"%@ [%@ %@]", step.instructions, MBStringFromManeuverType(step.maneuverType), MBStringFromManeuverDirection(step.maneuverDirection));
                 NSString *formattedDistance = [distanceFormatter stringFromMeters:step.distance];
-                NSLog(@"— %@ — %ld - %ld - %ld -", formattedDistance, step.maneuverType, step.maneuverDirection, step.transportType);
+                NSLog(@"— %@ for %@ —", MBStringFromTransportType(step.transportType), formattedDistance);
             }
             
             if (route.coordinateCount) {

--- a/Directions Example/ViewController.swift
+++ b/Directions Example/ViewController.swift
@@ -96,10 +96,10 @@ class ViewController: UIViewController, MBDrawingViewDelegate {
                 print("Distance: \(formattedDistance); ETA: \(formattedTravelTime!)")
                 
                 for step in leg.steps {
-                    print("\(step.instructions)")
+                    print("\(step.instructions) [\(step.maneuverType) \(step.maneuverDirection)]")
                     if step.distance > 0 {
                         let formattedDistance = distanceFormatter.string(fromMeters: step.distance)
-                        print("— \(formattedDistance) —")
+                        print("— \(step.transportType) for \(formattedDistance) —")
                     }
                 }
                 

--- a/MapboxDirections/MBRouteStep.swift
+++ b/MapboxDirections/MBRouteStep.swift
@@ -115,6 +115,13 @@ public enum TransportType: Int, CustomStringConvertible {
 }
 
 /**
+ Returns a string describing the given transport type.
+ */
+public func MBStringFromTransportType(transportType: TransportType) -> String {
+    return transportType.description
+}
+
+/**
  A `ManeuverType` specifies the type of maneuver required to complete the route step. You can pair a maneuver type with a `ManeuverDirection` to choose an appropriate visual or voice prompt to present the user.
 
  In Swift, you can use pattern matching with a single switch statement on a tuple containing the maneuver type and maneuver direction to avoid a complex series of if-else-if statements or switch statements.
@@ -348,6 +355,13 @@ public enum ManeuverType: Int, CustomStringConvertible {
 }
 
 /**
+ Returns a string describing the given maneuver type.
+ */
+public func MBStringFromManeuverType(maneuverType: ManeuverType) -> String {
+    return maneuverType.description
+}
+
+/**
  A `ManeuverDirection` clarifies a `ManeuverType` with directional information. The exact meaning of the maneuver direction for a given step depends on the step’s maneuver type; see the `ManeuverType` documentation for details.
  */
 @objc(MBManeuverDirection)
@@ -451,6 +465,13 @@ public enum ManeuverDirection: Int, CustomStringConvertible {
 }
 
 /**
+ Returns a string describing the given maneuver direction.
+ */
+public func MBStringFromManeuverDirection(maneuverDirection: ManeuverDirection) -> String {
+    return maneuverDirection.description
+}
+
+/**
  A `DrivingSide` indicates which side of the road cars and traffic flow.
  */
 @objc(MBDrivingSide)
@@ -487,6 +508,13 @@ public enum DrivingSide: Int, CustomStringConvertible {
             return "right"
         }
     }
+}
+
+/**
+ Returns a string describing the given driving side.
+ */
+public func MBStringFromDrivingSide(drivingSide: DrivingSide) -> String {
+    return drivingSide.description
 }
 
 extension String {


### PR DESCRIPTION
Added the `MBStringFromManeuverType()`, `MBStringFromManeuverDirection()`, `MBStringFromDrivingSide()`, and `MBStringFromTransportType()` functions, which are intended for use in Objective-C. Cleaned up the example application’s log output. Despite the usage in the example application, the new functions are only meant to expose the `description` of each enumeration, not a human-readable string.

/cc @frederoni