### PR TITLE
Migrate to Swift 5

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -115,6 +115,7 @@ workflows:
           xcode: "10.2.0"
           iOS: "12.2"
           tvOS: "12.2"
+          watchOS: "5.2"
           codecoverage: true
       - spm-job:
           name: "SPM_build"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,7 +44,7 @@ jobs:
         type: string
       device:
         type: string
-        default: "iPhone 6 Plus"
+        default: "iPhone 8 Plus"
       iOS:
         type: string
         default: "12.1"
@@ -99,22 +99,22 @@ jobs:
           command: xcodebuild -project MapboxDirections.xcodeproj -scheme 'MapboxDirections Mac' clean build<<# parameters.test >> test <</ parameters.test >><<# parameters.codecoverage >>-enableCodeCoverage YES<</ parameters.codecoverage >>
       - run:
           name: watchOS
-          command: xcodebuild -project MapboxDirections.xcodeproj -scheme 'MapboxDirections watchOS' -destination 'platform=watchOS Simulator,name=Apple Watch Series 3 - 42mm,OS=<< parameters.watchOS >>' clean build
+          command: xcodebuild -project MapboxDirections.xcodeproj -scheme 'MapboxDirections watchOS' -destination 'platform=watchOS Simulator,name=Apple Watch Series 4 - 44mm,OS=<< parameters.watchOS >>' clean build
 
 workflows:
   workflow:
     jobs:
       - build-job:
+          name: "Xcode_11.1"
+          xcode: "11.1.0"
+          iOS: "13.1"
+          tvOS: "13.0"
+          watchOS: "6.0"
+      - build-job:
           name: "Xcode_10.2"
           xcode: "10.2.0"
           iOS: "12.2"
           tvOS: "12.2"
-          watchOS: "5.2"
-      - build-job:
-          name: "Xcode_10.0"
-          xcode: "10.0.0"
-          iOS: "12.0"
-          tvOS: "12.0"
           codecoverage: true
       - spm-job:
           name: "SPM_build"

--- a/MapboxDirections.swift.podspec
+++ b/MapboxDirections.swift.podspec
@@ -44,7 +44,7 @@ Pod::Spec.new do |s|
 
   s.requires_arc = true
   s.module_name = "MapboxDirections"
-  s.swift_version = "4.0"
+  s.swift_version = "5.0"
 
   s.dependency "Polyline", "~> 4.2"
 

--- a/MapboxDirections.xcodeproj/project.pbxproj
+++ b/MapboxDirections.xcodeproj/project.pbxproj
@@ -1068,14 +1068,15 @@
 					};
 					DA6C9D871CAE442B00094FBC = {
 						CreatedOnToolsVersion = 7.3;
-						LastSwiftMigration = 1020;
+						LastSwiftMigration = 1100;
 					};
 					DA6C9D901CAE442B00094FBC = {
 						CreatedOnToolsVersion = 7.3;
-						LastSwiftMigration = 1020;
+						LastSwiftMigration = 1100;
 					};
 					DADD27B41E5AAAD800D31FAD = {
 						CreatedOnToolsVersion = 8.2.1;
+						LastSwiftMigration = 1100;
 						ProvisioningStyle = Automatic;
 					};
 					DADD27CF1E5AAFFD00D31FAD = {
@@ -1810,6 +1811,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
 				SWIFT_SWIFT3_OBJC_INFERENCE = Off;
+				SWIFT_VERSION = 5.0;
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
 			};
@@ -1837,6 +1839,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
 				SWIFT_SWIFT3_OBJC_INFERENCE = Off;
+				SWIFT_VERSION = 5.0;
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
 			};
@@ -1858,6 +1861,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "Tests/objc/MapboxDirectionsTests-Bridging-Header.h";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 5.0;
 			};
 			name = Debug;
 		};
@@ -1875,6 +1879,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.mapbox.MapboxDirectionsTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "Tests/objc/MapboxDirectionsTests-Bridging-Header.h";
+				SWIFT_VERSION = 5.0;
 			};
 			name = Release;
 		};
@@ -1898,6 +1903,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
 				SWIFT_SWIFT3_OBJC_INFERENCE = Off;
+				SWIFT_VERSION = 5.0;
 			};
 			name = Debug;
 		};
@@ -1919,6 +1925,7 @@
 				PRODUCT_MODULE_NAME = DirectionsExampleSwift;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_SWIFT3_OBJC_INFERENCE = Off;
+				SWIFT_VERSION = 5.0;
 			};
 			name = Release;
 		};

--- a/Tests/objc/BridgingTests.m
+++ b/Tests/objc/BridgingTests.m
@@ -29,8 +29,8 @@
     NSArray<CLLocation *> *locations = @[[[CLLocation alloc] initWithLatitude:0 longitude:1],
                                          [[CLLocation alloc] initWithLatitude:2 longitude:3]];
     
-    NSArray<NSValue *> *coordinates = @[[NSValue valueWithMKCoordinate:CLLocationCoordinate2DMake(0, 1)],
-                                        [NSValue valueWithMKCoordinate:CLLocationCoordinate2DMake(2, 3)]];
+//    NSArray<NSValue *> *coordinates = @[[NSValue valueWithMKCoordinate:CLLocationCoordinate2DMake(0, 1)],
+//                                        [NSValue valueWithMKCoordinate:CLLocationCoordinate2DMake(2, 3)]];
     
     NSArray<MBWaypoint *> *waypoints = @[[[MBWaypoint alloc] initWithCoordinate:CLLocationCoordinate2DMake(0, 1) coordinateAccuracy:-1 name:nil],
                                          [[MBWaypoint alloc] initWithCoordinate:CLLocationCoordinate2DMake(2, 3) coordinateAccuracy:-1 name:nil]];
@@ -38,7 +38,7 @@
     MBRouteOptions *options = nil;
     
     options = [[MBRouteOptions alloc] initWithLocations:locations profileIdentifier:MBDirectionsProfileIdentifierAutomobileAvoidingTraffic];
-    options = [[MBRouteOptions alloc] initWithCoordinates:coordinates profileIdentifier:MBDirectionsProfileIdentifierAutomobileAvoidingTraffic];
+//    options = [[MBRouteOptions alloc] initWithCoordinates:coordinates profileIdentifier:MBDirectionsProfileIdentifierAutomobileAvoidingTraffic];
     options = [[MBRouteOptions alloc] initWithWaypoints:waypoints profileIdentifier:MBDirectionsProfileIdentifierAutomobileAvoidingTraffic];
 }
 


### PR DESCRIPTION
Migrated to Swift 5 using the migrator in Xcode 11. Replaced the iOS 12.0 build bot with an iOS 13.1 build bot.

/cc @mapbox/navigation-ios