### PR TITLE
Keep access token out this repository

### DIFF
--- a/Directions Example/ViewController.m
+++ b/Directions Example/ViewController.m
@@ -3,10 +3,6 @@
 
 #import "ViewController.h"
 
-// A Mapbox access token is required to use the Directions API.
-// https://docs.mapbox.com/help/how-mapbox-works/access-tokens/#creating-and-managing-access-tokens
-NSString * const MapboxAccessToken = @"<# your Mapbox access token #>";
-
 @interface ViewController ()
 
 @property (nonatomic) MGLMapView *mapView;
@@ -17,9 +13,6 @@ NSString * const MapboxAccessToken = @"<# your Mapbox access token #>";
 
 - (void)viewDidLoad {
     [super viewDidLoad];
-    
-    NSAssert(![MapboxAccessToken isEqualToString:@"<# your Mapbox access token #>"], @"You must set `MapboxAccessToken` to your Mapbox access token.");
-    [MGLAccountManager setAccessToken:MapboxAccessToken];
     
     self.mapView = [[MGLMapView alloc] initWithFrame:self.view.bounds];
     self.mapView.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
@@ -36,7 +29,7 @@ NSString * const MapboxAccessToken = @"<# your Mapbox access token #>";
     MBRouteOptions *options = [[MBRouteOptions alloc] initWithWaypoints:waypoints profileIdentifier:nil];
     options.includesSteps = YES;
     
-    [[[MBDirections alloc] initWithAccessToken:MapboxAccessToken] calculateDirectionsWithOptions:options completionHandler:^(NSArray<MBWaypoint *> * _Nullable waypoints, NSArray<MBRoute *> * _Nullable routes, NSError * _Nullable error) {
+    [[MBDirections sharedDirections] calculateDirectionsWithOptions:options completionHandler:^(NSArray<MBWaypoint *> * _Nullable waypoints, NSArray<MBRoute *> * _Nullable routes, NSError * _Nullable error) {
         if (error) {
             NSLog(@"Error calculating directions: %@", error);
             return;

--- a/Directions Example/ViewController.swift
+++ b/Directions Example/ViewController.swift
@@ -3,10 +3,6 @@ import CoreLocation
 import MapboxDirections
 import Mapbox
 
-// A Mapbox access token is required to use the Directions API.
-// https://docs.mapbox.com/help/how-mapbox-works/access-tokens/#creating-and-managing-access-tokens
-let MapboxAccessToken = "<# your Mapbox access token #>"
-
 class ViewController: UIViewController, MBDrawingViewDelegate {
     @IBOutlet var mapView: MGLMapView!
     var drawingView: MBDrawingView?
@@ -16,9 +12,6 @@ class ViewController: UIViewController, MBDrawingViewDelegate {
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        
-        assert(MapboxAccessToken != "<# your Mapbox access token #>", "You must set `MapboxAccessToken` to your Mapbox access token.")
-        MGLAccountManager.accessToken = MapboxAccessToken
         
         mapView = MGLMapView(frame: view.bounds)
         mapView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
@@ -77,7 +70,7 @@ class ViewController: UIViewController, MBDrawingViewDelegate {
         let options = RouteOptions(waypoints: [wp1, wp2])
         options.includesSteps = true
         
-        Directions(accessToken: MapboxAccessToken).calculate(options) { (waypoints, routes, error) in
+        Directions.shared.calculate(options) { (waypoints, routes, error) in
             guard error == nil else {
                 print("Error calculating directions: \(error!)")
                 return
@@ -140,7 +133,7 @@ class ViewController: UIViewController, MBDrawingViewDelegate {
     func makeMatchRequest(locations: [CLLocationCoordinate2D]) {
         let matchOptions = MatchOptions(coordinates: locations)
 
-        Directions(accessToken: MapboxAccessToken).calculate(matchOptions) { (matches, error) in
+        Directions.shared.calculate(matchOptions) { (matches, error) in
             if let error = error {
                 print(error.localizedDescription)
                 return

--- a/MapboxDirections.xcodeproj/project.pbxproj
+++ b/MapboxDirections.xcodeproj/project.pbxproj
@@ -1006,6 +1006,7 @@
 				DADD27B31E5AAAD800D31FAD /* Resources */,
 				DADD27F51E5ABD6600D31FAD /* Copy Frameworks */,
 				C5AD867D202E251E00BF47D5 /* Embed Frameworks */,
+				DA3DFB08236973E9003AE57F /* Apply Mapbox Access Token */,
 			);
 			buildRules = (
 			);
@@ -1025,6 +1026,7 @@
 				DADD27CD1E5AAFFD00D31FAD /* Frameworks */,
 				DADD27CE1E5AAFFD00D31FAD /* Resources */,
 				DADD27F61E5AC7FA00D31FAD /* Copy Frameworks */,
+				DA3DFB09236975E5003AE57F /* Apply Mapbox Access Token */,
 			);
 			buildRules = (
 			);
@@ -1225,6 +1227,44 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
+		DA3DFB08236973E9003AE57F /* Apply Mapbox Access Token */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"$(TARGET_BUILD_DIR)/$(INFOPLIST_PATH)",
+			);
+			name = "Apply Mapbox Access Token";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "# Look for a global file named 'mapbox' or '.mapbox' within the home directory\ntoken_file=~/.mapbox\ntoken_file2=~/mapbox\ntoken=\"$(cat $token_file 2>/dev/null || cat $token_file2 2>/dev/null)\"\nif [ \"$token\" ]; then\n  plutil -replace MGLMapboxAccessToken -string $token \"$TARGET_BUILD_DIR/$INFOPLIST_PATH\"\nelse\n  echo 'warning: Missing Mapbox access token'\n  open 'https://account.mapbox.com/access-tokens/'\n  echo \"warning: Get an access token from <https://account.mapbox.com/access-tokens/>, then create a new file at $token_file or $token_file2 that contains the access token.\"\nfi\n";
+		};
+		DA3DFB09236975E5003AE57F /* Apply Mapbox Access Token */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"$(TARGET_BUILD_DIR)/$(INFOPLIST_PATH)",
+			);
+			name = "Apply Mapbox Access Token";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "# Look for a global file named 'mapbox' or '.mapbox' within the home directory\ntoken_file=~/.mapbox\ntoken_file2=~/mapbox\ntoken=\"$(cat $token_file 2>/dev/null || cat $token_file2 2>/dev/null)\"\nif [ \"$token\" ]; then\n  plutil -replace MGLMapboxAccessToken -string $token \"$TARGET_BUILD_DIR/$INFOPLIST_PATH\"\nelse\n  echo 'warning: Missing Mapbox access token'\n  open 'https://account.mapbox.com/access-tokens/'\n  echo \"warning: Get an access token from <https://account.mapbox.com/access-tokens/>, then create a new file at $token_file or $token_file2 that contains the access token.\"\nfi\n";
+		};
 		DADD27F51E5ABD6600D31FAD /* Copy Frameworks */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;


### PR DESCRIPTION
The Swift and Objective-C example application targets now read the access token [from an unversioned file at build time](https://docs.mapbox.com/help/troubleshooting/private-access-token-android-and-ios/). This way I’m much less likely to accidentally check in an access token of mine while developing the framework.

/ref mapbox/MapboxGeocoder.swift#23
/cc @mapbox/navigation-ios