### PR TITLE
Fix decoding of unrecognized visual instruction component types

### DIFF
--- a/Sources/MapboxDirections/VisualInstructionComponent.swift
+++ b/Sources/MapboxDirections/VisualInstructionComponent.swift
@@ -155,7 +155,7 @@ extension VisualInstruction.Component: Codable {
     
     public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
-        let kind = try container.decode(Kind.self, forKey: .kind)
+        let kind = (try? container.decode(Kind.self, forKey: .kind)) ?? .text
         
         if kind == .lane {
             let indications = try container.decode(LaneIndication.self, forKey: .directions)

--- a/Tests/MapboxDirectionsTests/VisualInstructionComponentTests.swift
+++ b/Tests/MapboxDirectionsTests/VisualInstructionComponentTests.swift
@@ -62,4 +62,23 @@ class VisualInstructionComponentTests: XCTestCase {
             XCTAssert(JSONSerialization.objectsAreEqual(componentJSON, encodedComponentJSON, approximate: false))
         }
     }
+    
+    func testUnrecognizedComponent() {
+        let componentJSON = [
+            "type": "emoji",
+            "text": "👈",
+        ]
+        let componentData = try! JSONSerialization.data(withJSONObject: componentJSON, options: [])
+        var component: VisualInstruction.Component?
+        XCTAssertNoThrow(component = try JSONDecoder().decode(VisualInstruction.Component.self, from: componentData))
+        XCTAssertNotNil(component)
+        if let component = component {
+            switch component {
+            case .text(let text):
+                XCTAssertEqual(text.text, "👈")
+            default:
+                XCTFail("Component of unrecognized type should be decoded as text component.")
+            }
+        }
+    }
 }


### PR DESCRIPTION
Fixed an issue where an unrecognized type of visual instruction component would cause the component to fail to decode. Instead, treat the component as a text component, as specified in [the Directions API documentation](https://docs.mapbox.com/api/navigation/#banner-instruction-object).

The regression was introduced in #382. This PR reintroduces pretty much the same code that we had before:

https://github.com/mapbox/MapboxDirections.swift/blob/65857d14080afa1e5463e0dbadd9dec23e66a6f3/Sources/MapboxDirections/MBVisualInstructionComponent.swift#L56

/cc @mapbox/navigation-ios @danpaz