### PR TITLE
Fix decoding Vienna Convention–style speed limits

### DIFF
--- a/Sources/MapboxDirections/RouteStep.swift
+++ b/Sources/MapboxDirections/RouteStep.swift
@@ -262,7 +262,7 @@ public enum SignStandard: String, Codable {
      
      This standard is prevalent in Europe and parts of Asia and Latin America. Countries in southern Africa and Central America have adopted similar regional standards.
      */
-    case viennaConvention
+    case viennaConvention = "vienna"
 }
 
 extension String {

--- a/Tests/MapboxDirectionsTests/AnnotationTests.swift
+++ b/Tests/MapboxDirectionsTests/AnnotationTests.swift
@@ -59,6 +59,7 @@ class AnnotationTests: XCTestCase {
             XCTAssertNotNil(route.shape)
             XCTAssertEqual(route.shape?.coordinates.count, 154)
             XCTAssertEqual(route.routeIdentifier, "ck4f22iso03fm78o2f96mt5e9")
+            XCTAssertEqual(route.legs.count, 1)
         }
         
         if let leg = route?.legs.first {

--- a/Tests/MapboxDirectionsTests/RouteStepTests.swift
+++ b/Tests/MapboxDirectionsTests/RouteStepTests.swift
@@ -182,6 +182,8 @@ class RouteStepTests: XCTestCase {
             "weight": 59.1,
             "name": "Adalbertstraße",
             "mode": "driving",
+            "speedLimitSign": "vienna",
+            "speedLimitUnit": "km/h",
         ] as [String : Any?]
         var stepData = try! JSONSerialization.data(withJSONObject: stepJSON, options: [])
         
@@ -190,6 +192,11 @@ class RouteStepTests: XCTestCase {
         var step: RouteStep?
         XCTAssertNoThrow(step = try decoder.decode(RouteStep.self, from: stepData))
         XCTAssertNotNil(step)
+        
+        if let step = step {
+            XCTAssertEqual(step.speedLimitSignStandard, SignStandard.viennaConvention)
+            XCTAssertEqual(step.speedLimitUnit, UnitSpeed.kilometersPerHour)
+        }
 
         let encoder = JSONEncoder()
         encoder.userInfo[.options] = options


### PR DESCRIPTION
Aliased `SignStandard.viennaConvention` to the value that appears in Directions API responses.