### PR TITLE
Fix round-tripping pronunciations

### DIFF
--- a/Sources/MapboxDirections/RouteStep.swift
+++ b/Sources/MapboxDirections/RouteStep.swift
@@ -478,10 +478,10 @@ open class RouteStep: Codable {
                         rotaryNames: isRound ? names : nil)
         try road.encode(to: encoder)
         if isRound {
-            try container.encodeIfPresent(phoneticNames, forKey: .rotaryPronunciation)
-            try container.encodeIfPresent(phoneticExitNames, forKey: .pronunciation)
+            try container.encodeIfPresent(phoneticNames?.tagValues(joinedBy: ";"), forKey: .rotaryPronunciation)
+            try container.encodeIfPresent(phoneticExitNames?.tagValues(joinedBy: ";"), forKey: .pronunciation)
         } else {
-            try container.encodeIfPresent(phoneticNames, forKey: .pronunciation)
+            try container.encodeIfPresent(phoneticNames?.tagValues(joinedBy: ";"), forKey: .pronunciation)
         }
         
         try container.encodeIfPresent(intersections, forKey: .intersections)

--- a/Tests/MapboxDirectionsTests/RouteStepTests.swift
+++ b/Tests/MapboxDirectionsTests/RouteStepTests.swift
@@ -247,4 +247,26 @@ class RouteStepTests: XCTestCase {
             }
         }
     }
+    
+    func testEncodingPronunciations() {
+        let options = RouteOptions(coordinates: [
+            CLLocationCoordinate2D(latitude: 0, longitude: 0),
+            CLLocationCoordinate2D(latitude: 1, longitude: 1),
+        ])
+        let step = RouteStep(transportType: .automobile, maneuverLocation: CLLocationCoordinate2D(latitude: 0, longitude: 0), maneuverType: .turn, maneuverDirection: .left, instructions: "", initialHeading: 0, finalHeading: 0, drivingSide: .right, distance: 10, expectedTravelTime: 10, names: ["iPhone X", "iPhone XS"], phoneticNames: ["ˈaɪˌfoʊ̯n ˈtɛn", "ˈaɪˌfoʊ̯n ˈtɛnz"])
+        
+        let encoder = JSONEncoder()
+        encoder.userInfo[.options] = options
+        var encodedStepData: Data?
+        XCTAssertNoThrow(encodedStepData = try encoder.encode(step))
+        XCTAssertNotNil(encodedStepData)
+        
+        if let encodedStepData = encodedStepData {
+            var encodedStepJSON: [String: Any?]?
+            XCTAssertNoThrow(encodedStepJSON = try JSONSerialization.jsonObject(with: encodedStepData, options: []) as? [String: Any?])
+            XCTAssertNotNil(encodedStepJSON)
+            
+            XCTAssertEqual(encodedStepJSON?["pronunciation"] as? String, "ˈaɪˌfoʊ̯n ˈtɛn; ˈaɪˌfoʊ̯n ˈtɛnz")
+        }
+    }
 }


### PR DESCRIPTION
In the API response’s RouteStep object, the `pronunciations` property is a semicolon-delimited string. We decode it as an array of strings for developer convenience but need to re-encode it as a semicolon-delimited string. Otherwise, a client such as MapboxNavigationNative could choke on an array where it expects a string.

/cc @mapbox/navigation-ios