### PR TITLE
Remove redundant library from Cartfile

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -1,3 +1,2 @@
 github "raphaelmor/Polyline" ~> 5.0
 github "mapbox/turf-swift" ~> 2.0
-github "apple/swift-argument-parser" ~> 1.0.0

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,5 +1,4 @@
 github "AliSoftware/OHHTTPStubs" "9.1.0"
-github "apple/swift-argument-parser" "1.0.1"
 github "mapbox/mapbox-events-ios" "v0.10.12"
 github "mapbox/turf-swift" "v2.0.0"
 github "raphaelmor/Polyline" "v5.0.2"


### PR DESCRIPTION
swift-argument-parser works only with SPM that is used for CLI tool. We don't support Carthage for CLI tool.
