### PR TITLE
Pin polyline

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -1,2 +1,2 @@
-github "raphaelmor/Polyline" ~> 5.0
+github "raphaelmor/Polyline" == 5.0.3
 github "mapbox/turf-swift" ~> 2.4


### PR DESCRIPTION
Carthage is [broken](https://circleci.com/gh/mapbox/mapbox-directions-swift/7409) due to [Polyline](https://github.com/raphaelmor/Polyline/releases/tag/v5.1.0) dropping iOS support. 

Carthage doesn't with Xcode 13.4.1, because MapboxDirections still support iOS 10 and Carthage tries to build all architectures, including armv7 which is not supported by Polyline anymore.