### PR TITLE
Revert "Add a job that will build documentation and create PR (#709)"

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,23 +40,6 @@ commands:
             - run:
                 name: Dependencies
                 command: carthage bootstrap --platform all --cache-builds --configuration Debug --use-xcframeworks   
-    install-mbx-ci:
-      steps:
-        - run:
-            name: "Install MBX CI"
-            command: |
-              curl -Ls https://mapbox-release-engineering.s3.amazonaws.com/mbx-ci/latest/mbx-ci-darwin-amd64 > /usr/local/bin/mbx-ci
-              chmod 755 /usr/local/bin/mbx-ci  
-    setup-write-repo-access:
-        steps:
-            - run:
-                name: Setup write access to the repo
-                command: |
-                    export GITHUB_TOKEN="$(mbx-ci github writer public token)"
-                    echo "export GITHUB_TOKEN='${GITHUB_TOKEN}'" >> $BASH_ENV
-                    git remote set-url origin "https://x-access-token:${GITHUB_TOKEN}@github.com/mapbox/mapbox-directions-swift.git"
-                    git config user.email "release-bot@mapbox.com"
-                    git config user.name "Mapbox Releases" 
 
 jobs:
   detect-breaking-changes:
@@ -209,24 +192,6 @@ jobs:
           command: xcodebuild -project MapboxDirections.xcodeproj -scheme 'MapboxDirections watchOS' -destination 'platform=watchOS Simulator,name=Apple Watch Series 5 - 44mm,OS=<< parameters.watchOS >>' clean build
       - save-cache
 
-  publish-documentation:
-    macos:
-      xcode: "12.5.1"
-    steps:
-      - checkout
-      - install-mapbox-token
-      - install-carthage
-      - install-mbx-ci
-      - run:
-          name: Generate Documentation
-          command: |
-            ./scripts/publish-documentation.sh << pipeline.git.tag >>
-      - setup-write-repo-access
-      - run:
-          name: "Push Generated Documentation"
-          command: |
-            git push origin $(git rev-parse --abbrev-ref HEAD):publisher-production
-
 workflows:
   workflow:
     jobs:
@@ -250,15 +215,3 @@ workflows:
           name: "SPM Ubuntu build"
       - example-app-build:
           name: "Build example app"
-      - approve-publish-documentation:
-          name: "Approve Publish Documentation"
-          type: approval
-          filters:
-            tags:
-              only: /^v\d+\.\d+\.\d+(-.+)?$/
-            branches:
-              ignore: /.*/
-      - publish-documentation:
-          name: "Publish Documentation"
-          requires:
-            - "Approve Publish Documentation"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -82,9 +82,8 @@ To release a new version of the MapboxDirections package:
 1. Tag the merged changes as `v#.#.#`. Push the tag by running `git pull && git push origin v#.#.#`.
 1. [Create a new release](https://github.com/mapbox/mapbox-directions-swift/releases/new/). Add release notes based on the release’s section in the changelog. (Unlike the changelog, release notes accept `#123` syntax for linking to PRs.) Title the release `v#.#.#`. Check “This is a pre-release” if applicable, then click “Publish release”.
 1. Run `pod repo update && pod trunk push MapboxDirections.podspec` (or `pod trunk push MapboxDirections-pre.podspec` for a prerelease) to publish the release on CocoaPods trunk.
-1. Open [CircleCI](https://app.circleci.com/pipelines/github/mapbox/mapbox-directions-swift?branch=main) and approve "Approve Publish Documentation" workflow for the release tag to publish documentation.
-1. Make sure that job runs successfully.
-1. Wait for new documentation to be live. The new version will be available within 10 minutes after job succeeds. (Mapbox employees can check the #publisher channel in Slack for a notification of when the commit has been published.)
+1. Run `./scripts/publish-documentation.sh v#.#.#` to generate and publish the documentation. Create a pull request and set the base branch to `publisher-production`.
+1. Wait for new documentation to be live. Once you merge the branch into `publisher-production`, the new version will be available within 10 minutes. (Mapbox employees can check the #publisher channel in Slack for a notification of when the commit has been published.)
 1. _(Mapbox employees only.)_ [Update various links](https://github.com/mapbox/ios-sdk#mapboxdirectionsswift) to the current docset in the [iOS documentation] site.
 1. _(Mapbox employees only.)_ [Update various links](https://github.com/mapbox/help/blob/publisher-production/docs/upgrading-versions.md) to the current docset in the [help](https://docs.mapbox.com/help/) site.
-1. For a new major version, upgrade the [iOS navigation SDK](https://github.com/mapbox/mapbox-navigation-ios/)’s Cartfile, podspecs, and Package.swift to the new version.
+1. For a new major version, upgrade the [iOS navigation SDK](https://github.com/mapbox/mapbox-navigation-ios/)’s Cartfile, podspecs, and Package.swift to the new version. 

--- a/scripts/publish-documentation.sh
+++ b/scripts/publish-documentation.sh
@@ -14,6 +14,7 @@ VERSION=${1}
 FOLDER=${VERSION:1} # removes first character from VERSION (v)
 
 step "Updating mapbox-directions-swift repository…"
+git fetch --depth=1 --prune
 git fetch --tags
 git checkout $RELEASE_BRANCH
 
@@ -23,7 +24,7 @@ step "Installing dependencies…"
 carthage bootstrap --cache-builds --use-xcframeworks
 
 step "Updating jazzy…"
-bundle install
+gem install jazzy
 
 step "Generating new docs for ${VERSION}…"
 OUTPUT=${OUTPUT} scripts/document.sh
@@ -34,7 +35,6 @@ mkdir -p "./$FOLDER"
 mv -v $OUTPUT/* "./$FOLDER"
 
 step "Switching branch to publisher-production"
-git checkout Gemfile.lock
 git checkout origin/publisher-production
 
 step "Committing API docs for $VERSION"


### PR DESCRIPTION
This reverts commit 0cb613196e13af28abc8646883c4470b4633608a.

I had to revert this change because it is not triggering. More work required to test how properly trigger flow on tag push.