### PR TITLE
Add publish documentation job that can be run for tags

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,6 +40,23 @@ commands:
             - run:
                 name: Dependencies
                 command: carthage bootstrap --platform all --cache-builds --configuration Debug --use-xcframeworks   
+    install-mbx-ci:
+      steps:
+        - run:
+            name: "Install MBX CI"
+            command: |
+              curl -Ls https://mapbox-release-engineering.s3.amazonaws.com/mbx-ci/latest/mbx-ci-darwin-amd64 > /usr/local/bin/mbx-ci
+              chmod 755 /usr/local/bin/mbx-ci  
+    setup-write-repo-access:
+        steps:
+            - run:
+                name: Setup write access to the repo
+                command: |
+                    export GITHUB_TOKEN="$(mbx-ci github writer public token)"
+                    echo "export GITHUB_TOKEN='${GITHUB_TOKEN}'" >> $BASH_ENV
+                    git remote set-url origin "https://x-access-token:${GITHUB_TOKEN}@github.com/mapbox/mapbox-directions-swift.git"
+                    git config user.email "release-bot@mapbox.com"
+                    git config user.name "Mapbox Releases" 
 
 jobs:
   detect-breaking-changes:
@@ -192,6 +209,24 @@ jobs:
           command: xcodebuild -project MapboxDirections.xcodeproj -scheme 'MapboxDirections watchOS' -destination 'platform=watchOS Simulator,name=Apple Watch Series 5 - 44mm,OS=<< parameters.watchOS >>' clean build
       - save-cache
 
+  publish-documentation:
+    macos:
+      xcode: "12.5.1"
+    steps:
+      - checkout
+      - install-mapbox-token
+      - install-carthage
+      - install-mbx-ci
+      - run:
+          name: Generate Documentation
+          command: |
+            ./scripts/publish-documentation.sh << pipeline.git.tag >>
+      - setup-write-repo-access
+      - run:
+          name: "Push Generated Documentation"
+          command: |
+            git push origin $(git rev-parse --abbrev-ref HEAD):publisher-production
+
 workflows:
   workflow:
     jobs:
@@ -215,3 +250,18 @@ workflows:
           name: "SPM Ubuntu build"
       - example-app-build:
           name: "Build example app"
+      - approve-publish-documentation:
+          name: "Approve Publish Documentation"
+          type: approval
+          filters: &filters-tag-push
+            tags:
+              only: /^v\d+\.\d+\.\d+(-.+)?$/
+            branches:
+              ignore: /.*/
+      - publish-documentation:
+          name: "Publish Documentation"
+          requires:
+            - "Approve Publish Documentation"
+          filters: 
+            <<: *filters-tag-push
+        

--- a/scripts/publish-documentation.sh
+++ b/scripts/publish-documentation.sh
@@ -14,7 +14,6 @@ VERSION=${1}
 FOLDER=${VERSION:1} # removes first character from VERSION (v)
 
 step "Updating mapbox-directions-swift repository…"
-git fetch --depth=1 --prune
 git fetch --tags
 git checkout $RELEASE_BRANCH
 
@@ -24,7 +23,7 @@ step "Installing dependencies…"
 carthage bootstrap --cache-builds --use-xcframeworks
 
 step "Updating jazzy…"
-gem install jazzy
+bundle install
 
 step "Generating new docs for ${VERSION}…"
 OUTPUT=${OUTPUT} scripts/document.sh
@@ -35,6 +34,7 @@ mkdir -p "./$FOLDER"
 mv -v $OUTPUT/* "./$FOLDER"
 
 step "Switching branch to publisher-production"
+git checkout Gemfile.lock
 git checkout origin/publisher-production
 
 step "Committing API docs for $VERSION"


### PR DESCRIPTION
This is a copy of already approved [PR](https://github.com/mapbox/mapbox-directions-swift/pull/709) but with a fix for job triggers. 

The issue seems to be that you have to specify triggers for all jobs in dependency graph or they won't run.

I don't update contributing guide here, because I want to make sure that this job triggers and works. Once it is achieved, I will push contributing guide update.