### PR TITLE
Update CI Xcode versions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -132,7 +132,7 @@ step-library:
 jobs:
   detect-breaking-changes:
     macos:
-      xcode: 15.2.0
+      xcode: 15.4.0
     steps:
       - checkout
       - install-mapbox-token
@@ -227,19 +227,19 @@ jobs:
     parameters:
       xcode:
         type: string
-        default: "15.2.0"
+        default: "15.4.0"
       device:
         type: string
         default: "iPhone 15 Pro"
       iOS:
         type: string
-        default: "17.2"
+        default: "17.5"
       watchOS:
         type: string
-        default: "10.2"
+        default: "10.5"
       tvOS:
         type: string
-        default: "17.2"
+        default: "17.5"
       test:
         type: boolean
         default: true
@@ -281,7 +281,7 @@ jobs:
 
   publish-documentation:
     macos:
-      xcode: "15.2.0"
+      xcode: "15.4.0"
     steps:
       - checkout
       - install-mapbox-token
@@ -301,7 +301,7 @@ jobs:
     parameters:
       xcode:
         type: string
-        default: "15.2.0"
+        default: "15.4.0"
     macos:
       xcode: << parameters.xcode >>
     environment:
@@ -329,7 +329,7 @@ jobs:
     parameters:
       xcode:
         type: string
-        default: "15.2.0"
+        default: "15.4.0"
     macos:
       xcode: << parameters.xcode >>
     environment:
@@ -381,26 +381,26 @@ workflows:
       - detect-breaking-changes:
           name: "Detect Breaking Changes"
       - build-job:
-          name: "Dev Build: Xcode 15.2"
+          name: "Dev Build: Xcode 15.4"
       - carthage-integration-test:
-          name: "Carthage Integration Test 15.2"
-          xcode: "15.2.0"
+          name: "Carthage Integration Test 15.4"
+          xcode: "15.4.0"
       - carthage-integration-test:
-          name: "Carthage Integration Test 14.0.0"
-          xcode: "14.0.0"
+          name: "Carthage Integration Test 14.3.1"
+          xcode: "14.3.1"
       - spm-job:
-          name: "SPM build 15.2"
-          xcode: "15.2.0"
+          name: "SPM build 15.4"
+          xcode: "15.4.0"
       - spm-job:
-          name: "SPM build 14.1.0"
-          xcode: "14.1.0"
+          name: "SPM build 14.3.1"
+          xcode: "14.3.1"
       - spm-linux-job:
           name: "SPM Ubuntu build"
       - example-app-build:
           name: "Build example app"
       - integration-test-with-navigation-sdk:
           name: "Integration Test With Navigation SDK"
-          xcode: "15.2.0"
+          xcode: "15.4.0"
       - publish-documentation:
           name: "Publish Documentation"
           filters:


### PR DESCRIPTION
Updated Xcode versions to 15.4 and 14.3.1 and corresponding simulator versions to match the available ones in CI images.