### PR TITLE
Fix geometry index range validation in Directions decoding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## v2.14.4
 
 * Added detection of duplicated URL request parameters derived from `DirectionsOptions`, `IsochroneOptions`, and `MatrixOptions` - an error is logged when duplicates are found.
+* Fixed a crash that could occur when decoding malformed traffic incident or road closure data in route responses.
 
 ## v2.14.3
 

--- a/Sources/MapboxDirections/Incident.swift
+++ b/Sources/MapboxDirections/Incident.swift
@@ -263,7 +263,6 @@ public struct Incident: Codable, Equatable, ForeignMemberContainer {
         
         let geometryIndexStart = try container.decode(Int.self, forKey: .geometryIndexStart)
         let geometryIndexEnd = try container.decode(Int.self, forKey: .geometryIndexEnd)
-        // Validate before constructing Range: Swift traps on inverted bounds instead of throwing.
         guard geometryIndexStart >= 0, geometryIndexStart <= geometryIndexEnd else {
             throw DecodingError.dataCorruptedError(
                 forKey: .geometryIndexEnd,

--- a/Sources/MapboxDirections/Incident.swift
+++ b/Sources/MapboxDirections/Incident.swift
@@ -263,6 +263,17 @@ public struct Incident: Codable, Equatable, ForeignMemberContainer {
         
         let geometryIndexStart = try container.decode(Int.self, forKey: .geometryIndexStart)
         let geometryIndexEnd = try container.decode(Int.self, forKey: .geometryIndexEnd)
+        // Validate before constructing Range: Swift traps on inverted bounds instead of throwing.
+        guard geometryIndexStart >= 0, geometryIndexStart <= geometryIndexEnd else {
+            throw DecodingError.dataCorruptedError(
+                forKey: .geometryIndexEnd,
+                in: container,
+                debugDescription: """
+                geometry_index_start (\(geometryIndexStart)) must be non-negative \
+                and less than or equal to geometry_index_end (\(geometryIndexEnd)).
+                """
+            )
+        }
         shapeIndexRange = geometryIndexStart..<geometryIndexEnd
         
         countryCodeAlpha3 = try container.decodeIfPresent(String.self, forKey: .countryCodeAlpha3)

--- a/Sources/MapboxDirections/RouteLeg.swift
+++ b/Sources/MapboxDirections/RouteLeg.swift
@@ -486,7 +486,6 @@ extension RouteLeg {
             
             let geometryIndexStart = try container.decode(Int.self, forKey: .geometryIndexStart)
             let geometryIndexEnd = try container.decode(Int.self, forKey: .geometryIndexEnd)
-            // Validate before constructing Range: Swift traps on inverted bounds instead of throwing.
             guard geometryIndexStart >= 0, geometryIndexStart <= geometryIndexEnd else {
                 throw DecodingError.dataCorruptedError(
                     forKey: .geometryIndexEnd,

--- a/Sources/MapboxDirections/RouteLeg.swift
+++ b/Sources/MapboxDirections/RouteLeg.swift
@@ -313,8 +313,11 @@ open class RouteLeg: Codable, ForeignMemberContainerClass {
     }
     
     private func adjustShapeIndexRange(_ range: Range<Int>, startLegShapeIndex: Int) -> Range<Int> {
-        let startIndex = startLegShapeIndex + range.lowerBound
-        let endIndex = startLegShapeIndex + range.upperBound
+        let (startIndex, startOverflow) = startLegShapeIndex.addingReportingOverflow(range.lowerBound)
+        let (endIndex, endOverflow) = startLegShapeIndex.addingReportingOverflow(range.upperBound)
+        // Refresh offsets may come from decoded payloads; collapse invalid math to an empty range.
+        guard !startOverflow, !endOverflow, startIndex >= 0, startIndex <= endIndex else { return 0..<0 }
+
         return startIndex..<endIndex
     }
     
@@ -483,6 +486,17 @@ extension RouteLeg {
             
             let geometryIndexStart = try container.decode(Int.self, forKey: .geometryIndexStart)
             let geometryIndexEnd = try container.decode(Int.self, forKey: .geometryIndexEnd)
+            // Validate before constructing Range: Swift traps on inverted bounds instead of throwing.
+            guard geometryIndexStart >= 0, geometryIndexStart <= geometryIndexEnd else {
+                throw DecodingError.dataCorruptedError(
+                    forKey: .geometryIndexEnd,
+                    in: container,
+                    debugDescription: """
+                    geometry_index_start (\(geometryIndexStart)) must be non-negative \
+                    and less than or equal to geometry_index_end (\(geometryIndexEnd)).
+                    """
+                )
+            }
             shapeIndexRange = geometryIndexStart..<geometryIndexEnd
             
             try decodeForeignMembers(notKeyedBy: CodingKeys.self, with: decoder)
@@ -516,9 +530,9 @@ public extension Array where Element == RouteLeg {
 private extension Array {
     mutating func replaceIfPossible(subrange: PartialRangeFrom<Int>, with newElements: Array?) {
         guard let newElements = newElements, !newElements.isEmpty else { return }
-        let upperBound = subrange.lowerBound + newElements.count
+        let (upperBound, overflow) = subrange.lowerBound.addingReportingOverflow(newElements.count)
         
-        guard count >= upperBound else { return }
+        guard subrange.lowerBound >= 0, !overflow, count >= upperBound else { return }
         
         let adjustedSubrange = subrange.lowerBound..<upperBound
         replaceSubrange(adjustedSubrange, with: newElements)

--- a/Tests/MapboxDirectionsTests/IncidentTests.swift
+++ b/Tests/MapboxDirectionsTests/IncidentTests.swift
@@ -2,6 +2,16 @@ import XCTest
 @testable import MapboxDirections
 
 final class IncidentTests: XCTestCase {
+    func testDecodingSucceedsWhenGeometryIndexRangeIsEmpty() throws {
+        let data = try makeIncidentData(overriding: [
+            "geometry_index_start": 5,
+            "geometry_index_end": 5,
+        ])
+
+        let incident = try JSONDecoder().decode(Incident.self, from: data)
+        XCTAssertEqual(incident.shapeIndexRange, 5..<5)
+    }
+
     func testDecodingFailsWhenGeometryIndexRangeIsInverted() throws {
         let data = try makeIncidentData(overriding: [
             "geometry_index_start": 5,

--- a/Tests/MapboxDirectionsTests/IncidentTests.swift
+++ b/Tests/MapboxDirectionsTests/IncidentTests.swift
@@ -1,0 +1,44 @@
+import XCTest
+@testable import MapboxDirections
+
+final class IncidentTests: XCTestCase {
+    func testDecodingFailsWhenGeometryIndexRangeIsInverted() throws {
+        let data = try makeIncidentData(overriding: [
+            "geometry_index_start": 5,
+            "geometry_index_end": 0,
+        ])
+
+        XCTAssertThrowsError(try JSONDecoder().decode(Incident.self, from: data))
+    }
+
+    func testDecodingFailsWhenGeometryIndexRangeIsNegative() throws {
+        let data = try makeIncidentData(overriding: [
+            "geometry_index_start": -1,
+            "geometry_index_end": 0,
+        ])
+
+        XCTAssertThrowsError(try JSONDecoder().decode(Incident.self, from: data))
+    }
+
+    private func makeIncidentData(overriding overrides: [String: Any?] = [:]) throws -> Data {
+        var dictionary: [String: Any] = [
+            "id": "test_id",
+            "type": "accident",
+            "description": "Test description",
+            "creation_time": "2021-01-01T10:00:00Z",
+            "start_time": "2021-01-01T09:00:00Z",
+            "end_time": "2021-01-01T12:00:00Z",
+            "alertc_codes": [Int](),
+            "geometry_index_start": 0,
+            "geometry_index_end": 5,
+        ]
+        for (key, value) in overrides {
+            if let value = value {
+                dictionary[key] = value
+            } else {
+                dictionary.removeValue(forKey: key)
+            }
+        }
+        return try JSONSerialization.data(withJSONObject: dictionary)
+    }
+}

--- a/Tests/MapboxDirectionsTests/RouteLegTests.swift
+++ b/Tests/MapboxDirectionsTests/RouteLegTests.swift
@@ -34,6 +34,20 @@ class RouteLegTests: XCTestCase {
         XCTAssertEqual(leg.typicalTravelTime, typicalTravelTime)
     }
 
+    func testDecodingSucceedsWhenClosureGeometryIndexRangeIsEmpty() throws {
+        let data = try makeRouteLegData(overriding: [
+            "closures": [
+                [
+                    "geometry_index_start": 5,
+                    "geometry_index_end": 5,
+                ],
+            ],
+        ])
+
+        let leg = try makeRouteLegDecoder().decode(RouteLeg.self, from: data)
+        XCTAssertEqual(leg.closures?.first?.shapeIndexRange, 5..<5)
+    }
+
     func testDecodingFailsWhenClosureGeometryIndexRangeIsInverted() throws {
         let data = try makeRouteLegData(overriding: [
             "closures": [
@@ -70,6 +84,28 @@ class RouteLegTests: XCTestCase {
         )
 
         XCTAssertEqual(leg.closures?.first?.shapeIndexRange, 0..<0)
+    }
+
+    func testRefreshIncidentsUsesEmptyRangeWhenAdjustedShapeIndexOverflows() throws {
+        let leg = try makeRouteLegDecoder().decode(RouteLeg.self, from: makeRouteLegData())
+        let incident = Incident(
+            identifier: "test_id",
+            type: .accident,
+            description: "Test description",
+            creationDate: Date(),
+            startDate: Date(),
+            endDate: Date(),
+            impact: nil,
+            subtype: nil,
+            subtypeDescription: nil,
+            alertCodes: [],
+            lanesBlocked: nil,
+            shapeIndexRange: 1..<2
+        )
+
+        leg.refreshIncidents(newIncidents: [incident], startLegShapeIndex: Int.max)
+
+        XCTAssertEqual(leg.incidents?.first?.shapeIndexRange, 0..<0)
     }
 
     func testRefreshAttributesDoesNotReplaceWhenStartIndexIsNegative() throws {

--- a/Tests/MapboxDirectionsTests/RouteLegTests.swift
+++ b/Tests/MapboxDirectionsTests/RouteLegTests.swift
@@ -33,4 +33,86 @@ class RouteLegTests: XCTestCase {
         XCTAssertEqual(leg.segmentRangesByStep.last?.upperBound, leg.segmentDistances?.count)
         XCTAssertEqual(leg.typicalTravelTime, typicalTravelTime)
     }
+
+    func testDecodingFailsWhenClosureGeometryIndexRangeIsInverted() throws {
+        let data = try makeRouteLegData(overriding: [
+            "closures": [
+                [
+                    "geometry_index_start": 5,
+                    "geometry_index_end": 0,
+                ],
+            ],
+        ])
+
+        XCTAssertThrowsError(try makeRouteLegDecoder().decode(RouteLeg.self, from: data))
+    }
+
+    func testDecodingFailsWhenClosureGeometryIndexRangeIsNegative() throws {
+        let data = try makeRouteLegData(overriding: [
+            "closures": [
+                [
+                    "geometry_index_start": -1,
+                    "geometry_index_end": 0,
+                ],
+            ],
+        ])
+
+        XCTAssertThrowsError(try makeRouteLegDecoder().decode(RouteLeg.self, from: data))
+    }
+
+    func testRefreshClosuresUsesEmptyRangeWhenAdjustedShapeIndexOverflows() throws {
+        let leg = try makeRouteLegDecoder().decode(RouteLeg.self, from: makeRouteLegData())
+        let closure = try makeClosureData(startIndex: 1, endIndex: 2)
+
+        leg.refreshClosures(
+            newClosures: [try JSONDecoder().decode(RouteLeg.Closure.self, from: closure)],
+            startLegShapeIndex: Int.max
+        )
+
+        XCTAssertEqual(leg.closures?.first?.shapeIndexRange, 0..<0)
+    }
+
+    func testRefreshAttributesDoesNotReplaceWhenStartIndexIsNegative() throws {
+        let leg = try makeRouteLegDecoder().decode(RouteLeg.self, from: makeRouteLegData())
+        leg.segmentDistances = [1, 2, 3]
+        var attributes = RouteLeg.Attributes()
+        attributes.segmentDistances = [9]
+
+        leg.refreshAttributes(newAttributes: attributes, startLegShapeIndex: -1)
+
+        XCTAssertEqual(leg.segmentDistances, [1, 2, 3])
+    }
+
+    private func makeRouteLegDecoder() -> JSONDecoder {
+        let decoder = JSONDecoder()
+        decoder.userInfo[.options] = RouteOptions(coordinates: [
+            LocationCoordinate2D(latitude: 0, longitude: 0),
+            LocationCoordinate2D(latitude: 1, longitude: 1),
+        ])
+        return decoder
+    }
+
+    private func makeRouteLegData(overriding overrides: [String: Any?] = [:]) throws -> Data {
+        var dict: [String: Any] = [
+            "summary": "Test Leg",
+            "distance": 100.0,
+            "duration": 60.0,
+            "steps": [Any](),
+        ]
+        for (key, value) in overrides {
+            if let value = value {
+                dict[key] = value
+            } else {
+                dict.removeValue(forKey: key)
+            }
+        }
+        return try JSONSerialization.data(withJSONObject: dict)
+    }
+
+    private func makeClosureData(startIndex: Int, endIndex: Int) throws -> Data {
+        return try JSONSerialization.data(withJSONObject: [
+            "geometry_index_start": startIndex,
+            "geometry_index_end": endIndex,
+        ])
+    }
 }


### PR DESCRIPTION
## Summary

- Validates traffic incident and road closure geometry index ranges before constructing Swift ranges.
- Converts malformed route response data into decoding errors instead of process-ending traps.
- Adds regression coverage for malformed incident/closure ranges and refresh helper bounds handling.